### PR TITLE
Add support for custom icon request handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Just explore the wiki to get started.
   - Regular request: Free to request
   - Premium request: Pay to request
   - Support for [Arctic Request Manager](https://arcticmanager.com)
+  - Support for custom implementations (e.g. Firestore or AWS Lambda)
 - Cloud based wallpaper
   - Preview wallpaper
   - Apply wallpaper

--- a/library/src/main/java/candybar/lib/applications/CandyBarApplication.java
+++ b/library/src/main/java/candybar/lib/applications/CandyBarApplication.java
@@ -120,7 +120,13 @@ public abstract class CandyBarApplication extends MultiDexApplication {
             String generate(List<Request> requests);
         }
 
+        public interface IconRequestHandler {
+            String submit(List<Request> requests, boolean isPremium);
+        }
+
         private EmailBodyGenerator mEmailBodyGenerator;
+
+        private IconRequestHandler iconRequestHandler;
 
         private NavigationIcon mNavigationIcon = NavigationIcon.STYLE_1;
         private NavigationViewHeader mNavigationViewHeader = NavigationViewHeader.NORMAL;
@@ -157,6 +163,11 @@ public abstract class CandyBarApplication extends MultiDexApplication {
 
         public Configuration setEmailBodyGenerator(EmailBodyGenerator emailBodyGenerator) {
             mEmailBodyGenerator = emailBodyGenerator;
+            return this;
+        }
+
+        public Configuration setIconRequestHandler(@NonNull IconRequestHandler iconRequestHandler) {
+            this.iconRequestHandler = iconRequestHandler;
             return this;
         }
 
@@ -304,6 +315,8 @@ public abstract class CandyBarApplication extends MultiDexApplication {
         public EmailBodyGenerator getEmailBodyGenerator() {
             return mEmailBodyGenerator;
         }
+
+        public IconRequestHandler getIconRequestHandler() { return iconRequestHandler; }
 
         public List<DonationLink> getDonationLinks() {
             return mDonationLinks;

--- a/library/src/main/java/candybar/lib/fragments/RequestFragment.java
+++ b/library/src/main/java/candybar/lib/fragments/RequestFragment.java
@@ -57,6 +57,7 @@ import candybar.lib.R;
 import candybar.lib.activities.CandyBarMainActivity;
 import candybar.lib.adapters.RequestAdapter;
 import candybar.lib.applications.CandyBarApplication;
+import candybar.lib.databases.Database;
 import candybar.lib.fragments.dialog.IntentChooserFragment;
 import candybar.lib.helpers.IconsHelper;
 import candybar.lib.helpers.RequestHelper;
@@ -440,9 +441,19 @@ public class RequestFragment extends Fragment implements View.OnClickListener {
 
                     if (isArctic) {
                         errorMessage = RequestHelper.sendArcticRequest(requests, files, directory, arcticApiKey);
+                        if (errorMessage == null) {
+                            for (Request request : requests) {
+                                Database.get(requireActivity()).addRequest(null, request);
+                            }
+                        }
                         return errorMessage == null;
                     } else if (isCustom) {
                         errorMessage = RequestHelper.sendCustomRequest(requests, isPremium);
+                        if (errorMessage == null) {
+                            for (Request request : requests) {
+                                Database.get(requireActivity()).addRequest(null, request);
+                            }
+                        }
                         return errorMessage == null;
                     } else {
                         boolean nonMailingAppSend = getResources().getBoolean(R.bool.enable_non_mail_app_request);

--- a/library/src/main/java/candybar/lib/fragments/RequestFragment.java
+++ b/library/src/main/java/candybar/lib/fragments/RequestFragment.java
@@ -70,6 +70,7 @@ import candybar.lib.utils.listeners.InAppBillingListener;
 import candybar.lib.utils.listeners.RequestListener;
 
 import static candybar.lib.helpers.DrawableHelper.getReqIcon;
+import static candybar.lib.helpers.DrawableHelper.getReqIconBase64;
 import static candybar.lib.helpers.ViewHelper.setFastScrollColor;
 
 /*
@@ -432,6 +433,9 @@ public class RequestFragment extends Fragment implements View.OnClickListener {
                         String icon = IconsHelper.saveIcon(files, directory, drawable,
                                 isArctic ? request.getPackageName() : RequestHelper.fixNameForRequest(request.getName()));
                         if (icon != null) files.add(icon);
+                        if (isCustom) {
+                            request.setIconBase64(getReqIconBase64(drawable));
+                        }
                     }
 
                     if (isArctic) {

--- a/library/src/main/java/candybar/lib/fragments/SettingsFragment.java
+++ b/library/src/main/java/candybar/lib/fragments/SettingsFragment.java
@@ -258,9 +258,21 @@ public class SettingsFragment extends Fragment {
 
                     if (isArctic) {
                         errorMessage = RequestHelper.sendArcticRequest(requests, files, directory, arcticApiKey);
+                        if (errorMessage == null) {
+                            for (Request request : requests) {
+                                Database.get(requireActivity()).addRequest(null, request);
+                                Database.get(requireActivity()).addPremiumRequest(null, request);
+                            }
+                        }
                         return errorMessage == null;
                     } else if (isCustom) {
                         errorMessage = RequestHelper.sendCustomRequest(requests, isPremium);
+                        if (errorMessage == null) {
+                            for (Request request : requests) {
+                                Database.get(requireActivity()).addRequest(null, request);
+                                Database.get(requireActivity()).addPremiumRequest(null, request);
+                            }
+                        }
                         return errorMessage == null;
                     } else {
                         File appFilter = RequestHelper.buildXml(requireActivity(), requests, RequestHelper.XmlType.APPFILTER);

--- a/library/src/main/java/candybar/lib/helpers/DrawableHelper.java
+++ b/library/src/main/java/candybar/lib/helpers/DrawableHelper.java
@@ -12,6 +12,7 @@ import android.graphics.drawable.AdaptiveIconDrawable;
 import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.Drawable;
 import android.os.Build;
+import android.util.Base64;
 import android.util.DisplayMetrics;
 import android.util.Log;
 
@@ -21,6 +22,8 @@ import androidx.core.content.ContextCompat;
 import androidx.core.content.res.ResourcesCompat;
 
 import com.danimahardhika.android.helpers.core.utils.LogUtil;
+
+import java.io.ByteArrayOutputStream;
 
 import candybar.lib.R;
 import sarsamurmu.adaptiveicon.AdaptiveIcon;
@@ -110,5 +113,13 @@ public class DrawableHelper {
         }
         return null;
     }
-}
 
+    public static String getReqIconBase64(@NonNull Drawable drawable) {
+        Bitmap appBitmap = getRightIcon(drawable);
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        assert appBitmap != null;
+        appBitmap.compress(Bitmap.CompressFormat.PNG, 100, baos);
+        String base64Icon = Base64.encodeToString(baos.toByteArray(), Base64.DEFAULT);
+        return base64Icon.trim();
+    }
+}

--- a/library/src/main/java/candybar/lib/helpers/RequestHelper.java
+++ b/library/src/main/java/candybar/lib/helpers/RequestHelper.java
@@ -289,6 +289,38 @@ public class RequestHelper {
         return null;
     }
 
+    public static boolean isRegularCustomEnabled(Context context) {
+        return context.getResources().getString(R.string.regular_request_method).length() > 0
+                && context.getResources().getString(R.string.regular_request_method).contentEquals("custom");
+    }
+
+    public static boolean isPremiumCustomEnabled(Context context) {
+        return (context.getResources().getString(R.string.premium_request_method).length() > 0
+                && context.getResources().getString(R.string.premium_request_method).contentEquals("custom"))
+                ||
+                // Fallback to regular request's method
+                (context.getResources().getString(R.string.regular_request_method).length() > 0
+                && context.getResources().getString(R.string.regular_request_method).contentEquals("custom"));
+    }
+
+    public static String sendCustomRequest(List<Request> requests, boolean isPremium) {
+        String errorMessage;
+        CandyBarApplication.Configuration.IconRequestHandler iconRequestHandler = CandyBarApplication.getConfiguration().getIconRequestHandler();
+        if (iconRequestHandler != null) {
+            errorMessage = iconRequestHandler.submit(requests, isPremium);
+        } else {
+            errorMessage = "Custom icon request failed: No handler configured";
+            LogUtil.e(errorMessage);
+            return errorMessage;
+        }
+        if (errorMessage == "") {
+            return null;
+        } else {
+            LogUtil.e(errorMessage);
+            return errorMessage;
+        }
+    }
+
     public static File getZipFile(List<String> files, String filepath, String filename) {
         // Modified from https://github.com/danimahardhika/android-helpers/blob/master/core/src/main/java/com/danimahardhika/android/helpers/core/FileHelper.java
         try {

--- a/library/src/main/java/candybar/lib/items/Request.java
+++ b/library/src/main/java/candybar/lib/items/Request.java
@@ -30,6 +30,7 @@ public class Request {
     private String mOrderId;
     private String mProductId;
     private String mRequestedOn;
+    private String mIconBase64;
     private boolean mRequested;
 
     private Request(String name, String activity) {
@@ -71,6 +72,8 @@ public class Request {
         return mRequestedOn;
     }
 
+    public String getIconBase64() { return mIconBase64; }
+
     public void setPackageName(String packageName) {
         mPackageName = packageName;
     }
@@ -90,6 +93,8 @@ public class Request {
     public void setRequested(boolean requested) {
         mRequested = requested;
     }
+
+    public void setIconBase64(String iconBase64) { mIconBase64 = iconBase64; }
 
     public static Builder Builder() {
         return new Builder();

--- a/library/src/main/res/values-de-rDE/dashboard_strings.xml
+++ b/library/src/main/res/values-de-rDE/dashboard_strings.xml
@@ -130,6 +130,8 @@ Google Play Store öffnen, um es herunterzuladen und es zu installieren?</string
     <string name="request_arctic_sending">Sende Request an Arctic Manager...</string>
     <string name="request_arctic_error">Fehler beim Senden des Requests an Arctic Manager. Die Fehlermeldung ist %s</string>
     <string name="request_arctic_success">Request erfolgreich an Arctic Manager gesendet</string>
+    <string name="request_custom_error">Fehler beim Senden des Icon Requests. Falls der Fehler wiederholt auftritt, wende dich an den Entwickler. %s</string>
+    <string name="request_custom_success">Icon Request erfolgreich gesendet</string>
     <string name="request_fetching_data">Rufe neueste Daten ab…</string>
     <string name="request_build_failed">Icon-Anfrage kann nicht erstellt werden</string>
     <string name="request_appfilter_failed">appfilter.xml kann nicht gelesen werden</string>

--- a/library/src/main/res/values/dashboard_configurations.xml
+++ b/library/src/main/res/values/dashboard_configurations.xml
@@ -185,9 +185,10 @@
         If you want to hide the information then you should enable this -->
     <bool name="hide_missing_app_count">false</bool>
 
-    <!-- Method to use for icon request. Value can be "email" or "arctic".
+    <!-- Method to use for icon request. Value can be "email", "arctic" or "custom".
         `email` -> Sends icon requests using email
         `arctic` -> Sends icon requests using Arctic Manager
+        `custom` -> Sends icon requests to a custom handler that needs to be configured separately
 
         You can leave "premium_request_method" empty to use the regular request's method to send premium icon requests. -->
     <string name="regular_request_method"></string>

--- a/library/src/main/res/values/dashboard_strings.xml
+++ b/library/src/main/res/values/dashboard_strings.xml
@@ -159,6 +159,8 @@
     <string name="request_arctic_sending">Sending request to Arctic Manager...</string>
     <string name="request_arctic_error">Error occurred while sending request to Arctic Manager. Error is %s</string>
     <string name="request_arctic_success">Successfully sent request to Arctic Manager</string>
+    <string name="request_custom_error">Error occurred while sending icon request. If this error persists, contact the developer. %s</string>
+    <string name="request_custom_success">Successfully sent icon request</string>
     <string name="request_fetching_data">Fetching latest data …</string>
     <string name="request_build_failed">Unable to build icon request</string>
     <string name="request_appfilter_failed">Unable to read appfilter.xml</string>


### PR DESCRIPTION
This PR adds an `IconRequestHandler` interface and a new accompanying request type `custom`. It allows users to add their own code for receiving and handling icon requests, e.g. by implementing connectors for AWS Lambda or Google Firestore.

To make handling icons easier, this PR also adds an additional property to the `Request` class that holds the Base64-encoded icon as a string. The property will only be populated if the request type is set to `custom`.

The way it works in the user's app:

```java
public class CandyBar extends CandyBarApplication {
    ...
    private static class MyCustomIconRequestHandler implements Configuration.IconRequestHandler {
        @Override
        public String submit(List<Request> requests, boolean isPremium) {
            // process the requests however you like
        }
    }
}
```

And then the CandyBar configuration allows to conveniently inject it:
```java
Configuration configuration = new Configuration();
configuration.setIconRequestHandler(new MyCustomIconRequestHandler());
```