### PR TITLE
Replace Arctic with Pacific

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Just explore the wiki to get started.
 - Icon request
   - Regular request: Free to request
   - Premium request: Pay to request
-  - Support for [Arctic Request Manager](https://arcticmanager.com)
+  - Support for [Pacific Request Manager](https://pacificmanager.app)
 - Cloud based wallpaper
   - Preview wallpaper
   - Apply wallpaper

--- a/app/src/main/res/values/dashboard_configurations.xml
+++ b/app/src/main/res/values/dashboard_configurations.xml
@@ -58,8 +58,8 @@
     <string name="premium_request_email"></string>
     <string name="regular_request_email_subject"></string>
     <string name="premium_request_email_subject"></string>
-    <string name="regular_request_arctic_api_key"><!--f2a96282-31d0-42b7-b802-5487f2931113--></string>
-    <string name="premium_request_arctic_api_key"></string>
+    <string name="regular_request_pacific_api_key"><!--f2a96282-31d0-42b7-b802-5487f2931113--></string>
+    <string name="premium_request_pacific_api_key"></string>
 
     <!-- CONFIG: CLOUD WALLPAPERS -->
     <string name="wallpaper_json">https://zixpo.github.io/candybar-sources/walls_alt.json</string>

--- a/library/src/main/java/candybar/lib/fragments/RequestFragment.java
+++ b/library/src/main/java/candybar/lib/fragments/RequestFragment.java
@@ -383,18 +383,18 @@ public class RequestFragment extends Fragment implements View.OnClickListener {
     private class RequestLoader extends AsyncTaskBase {
 
         private MaterialDialog dialog;
-        private boolean isArctic;
-        private String arcticApiKey;
+        private boolean isPacific;
+        private String pacificApiKey;
         private String errorMessage;
 
         @Override
         protected void preRun() {
             if (Preferences.get(requireActivity()).isPremiumRequest()) {
-                isArctic = RequestHelper.isPremiumArcticEnabled(requireActivity());
-                arcticApiKey = RequestHelper.getPremiumArcticApiKey(requireActivity());
+                isPacific = RequestHelper.isPremiumPacificEnabled(requireActivity());
+                pacificApiKey = RequestHelper.getPremiumPacificApiKey(requireActivity());
             } else {
-                isArctic = RequestHelper.isRegularArcticEnabled(requireActivity());
-                arcticApiKey = RequestHelper.getRegularArcticApiKey(requireActivity());
+                isPacific = RequestHelper.isRegularPacificEnabled(requireActivity());
+                pacificApiKey = RequestHelper.getRegularPacificApiKey(requireActivity());
             }
 
             dialog = new MaterialDialog.Builder(requireActivity())
@@ -424,12 +424,12 @@ public class RequestFragment extends Fragment implements View.OnClickListener {
                     for (Request request : requests) {
                         Drawable drawable = getReqIcon(requireActivity(), request.getActivity());
                         String icon = IconsHelper.saveIcon(files, directory, drawable,
-                                isArctic ? request.getPackageName() : RequestHelper.fixNameForRequest(request.getName()));
+                                isPacific ? request.getPackageName() : RequestHelper.fixNameForRequest(request.getName()));
                         if (icon != null) files.add(icon);
                     }
 
-                    if (isArctic) {
-                        errorMessage = RequestHelper.sendArcticRequest(requests, files, directory, arcticApiKey);
+                    if (isPacific) {
+                        errorMessage = RequestHelper.sendPacificRequest(requests, files, directory, pacificApiKey);
                         return errorMessage == null;
                     } else {
                         boolean nonMailingAppSend = getResources().getBoolean(R.bool.enable_non_mail_app_request);
@@ -510,8 +510,8 @@ public class RequestFragment extends Fragment implements View.OnClickListener {
             dialog = null;
 
             if (ok) {
-                if (isArctic) {
-                    Toast.makeText(getActivity(), R.string.request_arctic_success, Toast.LENGTH_LONG).show();
+                if (isPacific) {
+                    Toast.makeText(getActivity(), R.string.request_pacific_success, Toast.LENGTH_LONG).show();
                     ((RequestListener) getActivity()).onRequestBuilt(null, IntentChooserFragment.ICON_REQUEST);
                 } else {
                     IntentChooserFragment.showIntentChooserDialog(getActivity().getSupportFragmentManager(),
@@ -520,10 +520,10 @@ public class RequestFragment extends Fragment implements View.OnClickListener {
                 mAdapter.resetSelectedItems();
                 if (mMenuItem != null) mMenuItem.setIcon(R.drawable.ic_toolbar_select_all);
             } else {
-                if (isArctic) {
+                if (isPacific) {
                     new MaterialDialog.Builder(getActivity())
                             .typeface(TypefaceHelper.getMedium(getActivity()), TypefaceHelper.getRegular(getActivity()))
-                            .content(R.string.request_arctic_error, "\"" + errorMessage + "\"")
+                            .content(R.string.request_pacific_error, "\"" + errorMessage + "\"")
                             .cancelable(true)
                             .canceledOnTouchOutside(false)
                             .positiveText(R.string.close)

--- a/library/src/main/java/candybar/lib/fragments/SettingsFragment.java
+++ b/library/src/main/java/candybar/lib/fragments/SettingsFragment.java
@@ -208,15 +208,15 @@ public class SettingsFragment extends Fragment {
     private class PremiumRequestRebuilder extends AsyncTaskBase {
 
         private MaterialDialog dialog;
-        private boolean isArctic;
-        private String arcticApiKey;
+        private boolean isPacific;
+        private String pacificApiKey;
         private List<Request> requests;
         private String errorMessage = "";
 
         @Override
         protected void preRun() {
-            isArctic = RequestHelper.isPremiumArcticEnabled(requireActivity());
-            arcticApiKey = RequestHelper.getPremiumArcticApiKey(requireActivity());
+            isPacific = RequestHelper.isPremiumPacificEnabled(requireActivity());
+            pacificApiKey = RequestHelper.getPremiumPacificApiKey(requireActivity());
 
             dialog = new MaterialDialog.Builder(requireActivity())
                     .typeface(TypefaceHelper.getMedium(requireActivity()), TypefaceHelper.getRegular(requireActivity()))
@@ -244,12 +244,12 @@ public class SettingsFragment extends Fragment {
                     for (Request request : requests) {
                         Drawable drawable = getReqIcon(requireActivity(), request.getActivity());
                         String icon = IconsHelper.saveIcon(files, directory, drawable,
-                                isArctic ? request.getPackageName() : RequestHelper.fixNameForRequest(request.getName()));
+                                isPacific ? request.getPackageName() : RequestHelper.fixNameForRequest(request.getName()));
                         if (icon != null) files.add(icon);
                     }
 
-                    if (isArctic) {
-                        errorMessage = RequestHelper.sendArcticRequest(requests, files, directory, arcticApiKey);
+                    if (isPacific) {
+                        errorMessage = RequestHelper.sendPacificRequest(requests, files, directory, pacificApiKey);
                         return errorMessage == null;
                     } else {
                         File appFilter = RequestHelper.buildXml(requireActivity(), requests, RequestHelper.XmlType.APPFILTER);
@@ -296,8 +296,8 @@ public class SettingsFragment extends Fragment {
                     return;
                 }
 
-                if (isArctic) {
-                    Toast.makeText(getActivity(), R.string.request_arctic_success, Toast.LENGTH_LONG).show();
+                if (isPacific) {
+                    Toast.makeText(getActivity(), R.string.request_pacific_success, Toast.LENGTH_LONG).show();
                     ((RequestListener) getActivity()).onRequestBuilt(null, IntentChooserFragment.REBUILD_ICON_REQUEST);
                 } else {
                     IntentChooserFragment.showIntentChooserDialog(

--- a/library/src/main/java/candybar/lib/helpers/RequestHelper.java
+++ b/library/src/main/java/candybar/lib/helpers/RequestHelper.java
@@ -187,9 +187,9 @@ public class RequestHelper {
 
     public static String getRegularPacificApiKey(Context context) {
         String pacificApiKey = context.getResources().getString(R.string.regular_request_pacific_api_key);
-        // Fallback to pacific_manager_api_key
+        // Fallback to arctic_manager_api_key
         if (pacificApiKey.length() == 0)
-            pacificApiKey = context.getResources().getString(R.string.pacific_manager_api_key);
+            pacificApiKey = context.getResources().getString(R.string.arctic_manager_api_key);
 
         return pacificApiKey;
     }

--- a/library/src/main/java/candybar/lib/helpers/RequestHelper.java
+++ b/library/src/main/java/candybar/lib/helpers/RequestHelper.java
@@ -236,49 +236,16 @@ public class RequestHelper {
                 .post(okRequestBody)
                 .build();
 
-        OkHttpClient.Builder clientBuilder = new OkHttpClient.Builder();
-
-        // Disable SSL verification
-        try {
-            final X509TrustManager[] trustManagers = new X509TrustManager[]{
-                    new X509TrustManager() {
-                        @SuppressLint("TrustAllX509TrustManager")
-                        @Override
-                        public void checkClientTrusted(X509Certificate[] a, String b) {
-                        }
-
-                        @SuppressLint("TrustAllX509TrustManager")
-                        @Override
-                        public void checkServerTrusted(X509Certificate[] a, String b) {
-                        }
-
-                        @SuppressLint("TrustAllX509TrustManager")
-                        public void checkServerTrusted(X509Certificate[] a, String b, String c) {
-                        }
-
-                        @SuppressLint("TrustAllX509TrustManager")
-                        public void checkServerTrusted(X509Certificate[] a, String b, String c, String d) {
-                        }
-
-                        @Override
-                        public X509Certificate[] getAcceptedIssuers() {
-                            return new X509Certificate[]{};
-                        }
-                    }
-            };
-            final SSLContext sslContext = SSLContext.getInstance("SSL");
-            sslContext.init(null, trustManagers, new SecureRandom());
-            clientBuilder.hostnameVerifier((hostname, session) -> true);
-            clientBuilder.sslSocketFactory(sslContext.getSocketFactory(), trustManagers[0]);
-        } catch (Exception e) {
-            LogUtil.e(Log.getStackTraceString(e));
-        }
+        okhttp3.OkHttpClient okHttpClient = new okhttp3.OkHttpClient();
 
         try {
-            okhttp3.Response response = clientBuilder.build().newCall(okRequest).execute();
+            okhttp3.Response response = okHttpClient.newCall(okRequest).execute();
             boolean success = response.code() > 199 && response.code() < 300;
             if (!success) {
-                JSONObject responseJson = new JSONObject(Objects.requireNonNull(response.body()).string());
+                return "Unknown error.";
+            }
+            JSONObject responseJson = new JSONObject(Objects.requireNonNull(response.body()).string());
+            if(responseJson.getString("status").equals("error")) {
                 return responseJson.getString("error");
             }
         } catch (IOException | JSONException e) {

--- a/library/src/main/java/candybar/lib/helpers/RequestHelper.java
+++ b/library/src/main/java/candybar/lib/helpers/RequestHelper.java
@@ -140,7 +140,7 @@ public class RequestHelper {
         return null;
     }
 
-    public static String buildJsonForArctic(@NonNull List<Request> requests) {
+    public static String buildJsonForPacific(@NonNull List<Request> requests) {
         StringBuilder sb = new StringBuilder();
         boolean isFirst = true;
 
@@ -185,51 +185,51 @@ public class RequestHelper {
         return sb.toString();
     }
 
-    public static String getRegularArcticApiKey(Context context) {
-        String arcticApiKey = context.getResources().getString(R.string.regular_request_arctic_api_key);
-        // Fallback to arctic_manager_api_key
-        if (arcticApiKey.length() == 0)
-            arcticApiKey = context.getResources().getString(R.string.arctic_manager_api_key);
+    public static String getRegularPacificApiKey(Context context) {
+        String pacificApiKey = context.getResources().getString(R.string.regular_request_pacific_api_key);
+        // Fallback to pacific_manager_api_key
+        if (pacificApiKey.length() == 0)
+            pacificApiKey = context.getResources().getString(R.string.pacific_manager_api_key);
 
-        return arcticApiKey;
+        return pacificApiKey;
     }
 
-    public static boolean isRegularArcticEnabled(Context context) {
+    public static boolean isRegularPacificEnabled(Context context) {
         return context.getResources().getString(R.string.regular_request_method).length() > 0
-                ? context.getResources().getString(R.string.regular_request_method).contentEquals("arctic")
-                // Use fallback method to check if arctic is enabled
-                : getRegularArcticApiKey(context).length() > 0;
+                ? context.getResources().getString(R.string.regular_request_method).contentEquals("pacific")
+                // Use fallback method to check if pacific is enabled
+                : getRegularPacificApiKey(context).length() > 0;
     }
 
-    public static String getPremiumArcticApiKey(Context context) {
-        String arcticApiKey = context.getResources().getString(R.string.premium_request_arctic_api_key);
+    public static String getPremiumPacificApiKey(Context context) {
+        String pacificApiKey = context.getResources().getString(R.string.premium_request_pacific_api_key);
         // Fallback to regular request's api key
-        if (arcticApiKey.length() == 0) arcticApiKey = getRegularArcticApiKey(context);
+        if (pacificApiKey.length() == 0) pacificApiKey = getRegularPacificApiKey(context);
 
-        return arcticApiKey;
+        return pacificApiKey;
     }
 
-    public static boolean isPremiumArcticEnabled(Context context) {
+    public static boolean isPremiumPacificEnabled(Context context) {
         return context.getResources().getString(R.string.premium_request_method).length() > 0
-                ? context.getResources().getString(R.string.premium_request_method).contentEquals("arctic")
+                ? context.getResources().getString(R.string.premium_request_method).contentEquals("pacific")
                 // Fallback to regular request's method
                 : context.getResources().getString(R.string.regular_request_method).length() > 0
-                ? context.getResources().getString(R.string.regular_request_method).contentEquals("arctic")
-                // Use fallback method to check if arctic is enabled
-                : getRegularArcticApiKey(context).length() > 0;
+                ? context.getResources().getString(R.string.regular_request_method).contentEquals("pacific")
+                // Use fallback method to check if pacific is enabled
+                : getRegularPacificApiKey(context).length() > 0;
     }
 
-    public static String sendArcticRequest(List<Request> requests, List<String> iconFiles, File directory, String apiKey) {
+    public static String sendPacificRequest(List<Request> requests, List<String> iconFiles, File directory, String apiKey) {
         okhttp3.RequestBody okRequestBody = new okhttp3.MultipartBody.Builder()
                 .setType(okhttp3.MultipartBody.FORM)
-                .addFormDataPart("apps", buildJsonForArctic(requests))
+                .addFormDataPart("apps", buildJsonForPacific(requests))
                 .addFormDataPart("archive", "icons.zip", okhttp3.RequestBody.create(
                         Objects.requireNonNull(getZipFile(iconFiles, directory.toString(), "icons.zip")),
                         okhttp3.MediaType.parse("application/zip")))
                 .build();
 
         okhttp3.Request okRequest = new okhttp3.Request.Builder()
-                .url("https://arcticmanager.com/v1/request")
+                .url("https://pacificmanager.app/v1/request")
                 .addHeader("TokenID", apiKey)
                 .addHeader("Accept", "application/json")
                 .addHeader("User-Agent", "afollestad/icon-request")
@@ -282,7 +282,7 @@ public class RequestHelper {
                 return responseJson.getString("error");
             }
         } catch (IOException | JSONException e) {
-            LogUtil.e("ARCTIC_MANAGER: Error");
+            LogUtil.e("PACIFIC_MANAGER: Error");
             LogUtil.e(Log.getStackTraceString(e));
             return "";
         }

--- a/library/src/main/res/values-ar-rSA/dashboard_strings.xml
+++ b/library/src/main/res/values-ar-rSA/dashboard_strings.xml
@@ -125,9 +125,9 @@
     <string name="request_not_requested">لم يتم طلبه</string>
     <string name="request_already_requested">تم طلبه بالفعل</string>
     <string name="request_building">جار بناء الطلب ...</string>
-    <string name="request_arctic_sending">جار إرسال الطلب إلى Arctic Manager...</string>
-    <string name="request_arctic_error">حدث خطأ أثناء إرسال الطلب إلى Arctic Manager. الخطأ هو %s</string>
-    <string name="request_arctic_success">تم إرسال الطلب بنجاح إلى Arctic Manager</string>
+    <string name="request_pacific_sending">جار إرسال الطلب إلى Pacific Manager...</string>
+    <string name="request_pacific_error">حدث خطأ أثناء إرسال الطلب إلى Pacific Manager. الخطأ هو %s</string>
+    <string name="request_pacific_success">تم إرسال الطلب بنجاح إلى Pacific Manager</string>
     <string name="request_fetching_data">جار جلب أحدث البيانات …</string>
     <string name="request_build_failed">تعذر بناء طلب الأيقونات</string>
     <string name="request_appfilter_failed">تعذر قراءة appfilter.xml</string>

--- a/library/src/main/res/values-cs-rCZ/dashboard_strings.xml
+++ b/library/src/main/res/values-cs-rCZ/dashboard_strings.xml
@@ -127,9 +127,9 @@
     <string name="request_not_requested">Nepožádáno</string>
     <string name="request_already_requested">Již požádáno</string>
     <string name="request_building">Připravuji požadavek…</string>
-    <string name="request_arctic_sending">Odesílání požadavku do Artic Manager...</string>
-    <string name="request_arctic_error">Při odesílání požadavku do Artic Manager došlo k chybě. Chyba je %s</string>
-    <string name="request_arctic_success">Požadavek byl úspěšně odeslán do Arctic Manager</string>
+    <string name="request_pacific_sending">Odesílání požadavku do Pacific Manager...</string>
+    <string name="request_pacific_error">Při odesílání požadavku do Pacific Manager došlo k chybě. Chyba je %s</string>
+    <string name="request_pacific_success">Požadavek byl úspěšně odeslán do Pacific Manager</string>
     <string name="request_fetching_data">Načítání nejnovějších dat…</string>
     <string name="request_build_failed">Nelze sestavit požadavek</string>
     <string name="request_appfilter_failed">Nelze načíst appfilter.xml</string>

--- a/library/src/main/res/values-de-rDE/dashboard_strings.xml
+++ b/library/src/main/res/values-de-rDE/dashboard_strings.xml
@@ -127,9 +127,9 @@ Google Play Store öffnen, um es herunterzuladen und es zu installieren?</string
     <string name="request_not_requested">Nicht angefragt</string>
     <string name="request_already_requested">Bereits angefragt</string>
     <string name="request_building">Anfrage erstellen …</string>
-    <string name="request_arctic_sending">Sende Request an Arctic Manager...</string>
-    <string name="request_arctic_error">Fehler beim Senden des Requests an Arctic Manager. Die Fehlermeldung ist %s</string>
-    <string name="request_arctic_success">Request erfolgreich an Arctic Manager gesendet</string>
+    <string name="request_pacific_sending">Sende Request an Pacific Manager...</string>
+    <string name="request_pacific_error">Fehler beim Senden des Requests an Pacific Manager. Die Fehlermeldung ist %s</string>
+    <string name="request_pacific_success">Request erfolgreich an Pacific Manager gesendet</string>
     <string name="request_fetching_data">Rufe neueste Daten ab…</string>
     <string name="request_build_failed">Icon-Anfrage kann nicht erstellt werden</string>
     <string name="request_appfilter_failed">appfilter.xml kann nicht gelesen werden</string>

--- a/library/src/main/res/values-es-rES/dashboard_strings.xml
+++ b/library/src/main/res/values-es-rES/dashboard_strings.xml
@@ -121,9 +121,9 @@ No podrás utilizar la aplicación.</string>
     <string name="request_not_requested">No solicitado</string>
     <string name="request_already_requested">Ya solicitado</string>
     <string name="request_building">Preparando la solicitud …</string>
-    <string name="request_arctic_sending">Enviando solicitud al Arctic Manager...</string>
-    <string name="request_arctic_error">Error al enviar la solicitud al Arctic Manager. El error es %s</string>
-    <string name="request_arctic_success">Solicitud enviada correctamente al Arctic Manager</string>
+    <string name="request_pacific_sending">Enviando solicitud al Pacific Manager...</string>
+    <string name="request_pacific_error">Error al enviar la solicitud al Pacific Manager. El error es %s</string>
+    <string name="request_pacific_success">Solicitud enviada correctamente al Pacific Manager</string>
     <string name="request_build_failed">No se puede preparar la solicitud del icono</string>
     <string name="request_appfilter_failed">No se puede leer appfilter.xml</string>
     <string name="request_requested">Por favor comprueba tu solicitud de nuevo, porque estás solicitando una aplicación que ya ha sido solicitada anteriormente.</string>

--- a/library/src/main/res/values-fr-rFR/dashboard_strings.xml
+++ b/library/src/main/res/values-fr-rFR/dashboard_strings.xml
@@ -128,9 +128,9 @@ Vous avez besoin d\'un lanceur tiers pour utiliser un pack d\'icônes.</string>
     <string name="request_not_requested">Non demandée</string>
     <string name="request_already_requested">Déjà demandée</string>
     <string name="request_building">Construction de la demande …</string>
-    <string name="request_arctic_sending">Envoi de la demande à Artic Manager...</string>
-    <string name="request_arctic_error">Échec de l\'envoi de la demande à Artic Manager. L\'erreur est %s</string>
-    <string name="request_arctic_success">Demande envoyée avec succès à Artic Manager</string>
+    <string name="request_pacific_sending">Envoi de la demande à Artic Manager...</string>
+    <string name="request_pacific_error">Échec de l\'envoi de la demande à Artic Manager. L\'erreur est %s</string>
+    <string name="request_pacific_success">Demande envoyée avec succès à Artic Manager</string>
     <string name="request_fetching_data">Récupération des dernières données...</string>
     <string name="request_build_failed">Impossible de construire la demande d\'icône(s)</string>
     <string name="request_appfilter_failed">Impossible de lire le fichier appfilter.xml</string>

--- a/library/src/main/res/values-hu-rHU/dashboard_strings.xml
+++ b/library/src/main/res/values-hu-rHU/dashboard_strings.xml
@@ -113,9 +113,9 @@
     <string name="request_not_requested">Nincs elküldve</string>
     <string name="request_already_requested">Már elküldve</string>
     <string name="request_building">Kérés létrehozása …</string>
-    <string name="request_arctic_sending">Kérés küldése az Arctic Manager-nek...</string>
-    <string name="request_arctic_error">Az Arctic Manager hibába ütközött a kérés elküldése közben. A hiba oka: %s</string>
-    <string name="request_arctic_success">A kérelem az Arctic Managernek sikeresen elküldve</string>
+    <string name="request_pacific_sending">Kérés küldése az Pacific Manager-nek...</string>
+    <string name="request_pacific_error">Az Pacific Manager hibába ütközött a kérés elküldése közben. A hiba oka: %s</string>
+    <string name="request_pacific_success">A kérelem az Pacific Managernek sikeresen elküldve</string>
     <string name="request_fetching_data">Adatok betöltése…</string>
     <string name="request_build_failed">Ikonkérés nem hozható létre</string>
     <string name="request_appfilter_failed">appfilter.xml nem található</string>

--- a/library/src/main/res/values-in-rID/dashboard_strings.xml
+++ b/library/src/main/res/values-in-rID/dashboard_strings.xml
@@ -126,9 +126,9 @@ dengan memesan ikon premium anda bisa mendapatkan pesanan aplikasi lebih cepat.<
     <string name="request_not_requested">Tidak dipesan</string>
     <string name="request_already_requested">Sudah dipesan</string>
     <string name="request_building">Membuat pesanan…</string>
-    <string name="request_arctic_sending">Mengirim pesanan ke Arctic Manager...</string>
-    <string name="request_arctic_error">Terjadi kesalahan ketika mengirim pesanan ke Arctic Manager. Kesalahan %s</string>
-    <string name="request_arctic_success">Berhasil kirim pesanan ke Arctic Manager</string>
+    <string name="request_pacific_sending">Mengirim pesanan ke Pacific Manager...</string>
+    <string name="request_pacific_error">Terjadi kesalahan ketika mengirim pesanan ke Pacific Manager. Kesalahan %s</string>
+    <string name="request_pacific_success">Berhasil kirim pesanan ke Pacific Manager</string>
     <string name="request_fetching_data">Mengambil data terbaru…</string>
     <string name="request_build_failed">Tidak dapat membuat pesanan ikon</string>
     <string name="request_appfilter_failed">Tidak dapat membaca appfilter.xml</string>

--- a/library/src/main/res/values-it-rIT/dashboard_strings.xml
+++ b/library/src/main/res/values-it-rIT/dashboard_strings.xml
@@ -124,9 +124,9 @@ Scaricala da lì per utilizzarla.</string>
     <string name="request_not_requested">Non richiesta</string>
     <string name="request_already_requested">Richiesta già effettuata</string>
     <string name="request_building">Caricamento richiesta …</string>
-    <string name="request_arctic_sending">Invio della richiesta a Arctic Manager...</string>
-    <string name="request_arctic_error">Si è verificato un errore durante l\'invio della richiesta a Arctic Manager. L\'errore è %s</string>
-    <string name="request_arctic_success">Richiesta inviata con successo a Arctic Manager</string>
+    <string name="request_pacific_sending">Invio della richiesta a Pacific Manager...</string>
+    <string name="request_pacific_error">Si è verificato un errore durante l\'invio della richiesta a Pacific Manager. L\'errore è %s</string>
+    <string name="request_pacific_success">Richiesta inviata con successo a Pacific Manager</string>
     <string name="request_fetching_data">Recupero dati più recenti…</string>
     <string name="request_build_failed">Impossibile caricare la richiesta delle icone</string>
     <string name="request_appfilter_failed">impossibile leggere appfilter.xml</string>

--- a/library/src/main/res/values-nb-rNO/dashboard_strings.xml
+++ b/library/src/main/res/values-nb-rNO/dashboard_strings.xml
@@ -156,9 +156,9 @@
     <string name="request_already_requested">Allerede forespurt</string>
 
     <string name="request_building">Bygger forespørsel …</string>
-    <string name="request_arctic_sending">Sender forespørsel til Arctic-håndterer …</string>
-    <string name="request_arctic_error">Kunne ikke sende forespørsel til Arctic-håndterer. Feilen er %s</string>
-    <string name="request_arctic_success">Sendte forespørsel til Arctic-håndterer</string>
+    <string name="request_pacific_sending">Sender forespørsel til Pacific-håndterer …</string>
+    <string name="request_pacific_error">Kunne ikke sende forespørsel til Pacific-håndterer. Feilen er %s</string>
+    <string name="request_pacific_success">Sendte forespørsel til Pacific-håndterer</string>
     <string name="request_fetching_data">Henter oppdatert data …</string>
     <string name="request_build_failed">Kunne ikke bygge ikonforespørsel</string>
     <string name="request_appfilter_failed">Kunne ikke lese appfilter.xml</string>

--- a/library/src/main/res/values-ne-rNP/dashboard_strings.xml
+++ b/library/src/main/res/values-ne-rNP/dashboard_strings.xml
@@ -123,9 +123,9 @@
     <string name="request_not_requested">अनुरोध गरिएको छैन</string>
     <string name="request_already_requested">पहिले नै अनुरोध गरीसकेको </string>
     <string name="request_building">अनुरोध निर्माण गरिदैछ…</string>
-    <string name="request_arctic_sending">Arctic Manager लाई अनुरोध पठाउदै..</string>
-    <string name="request_arctic_error">Arctic Manager लाई अनुरोध पठाउदै गर्दा समस्या देखियो । समस्या चाँही  %s हो ।</string>
-    <string name="request_arctic_success">Arctic Manager लाई सफलतापूर्वक अनुरोध पठाईयो ।</string>
+    <string name="request_pacific_sending">Pacific Manager लाई अनुरोध पठाउदै..</string>
+    <string name="request_pacific_error">Pacific Manager लाई अनुरोध पठाउदै गर्दा समस्या देखियो । समस्या चाँही  %s हो ।</string>
+    <string name="request_pacific_success">Pacific Manager लाई सफलतापूर्वक अनुरोध पठाईयो ।</string>
     <string name="request_fetching_data">भर्खरैको डाटा ल्याउँदै...</string>
     <string name="request_build_failed">आइकनको अनुरोध निर्माण गर्न सकिएन</string>
     <string name="request_appfilter_failed">appfilter.xml पढ्न सकिएन</string>

--- a/library/src/main/res/values-nl-rNL/dashboard_strings.xml
+++ b/library/src/main/res/values-nl-rNL/dashboard_strings.xml
@@ -125,9 +125,9 @@
     <string name="request_not_requested">Niet aangevraagd</string>
     <string name="request_already_requested">Reeds aangevraagd</string>
     <string name="request_building">Aanvraag aanmaken…</string>
-    <string name="request_arctic_sending">Aanvraag versturen naar Arctic Manager...</string>
-    <string name="request_arctic_error">Fout tijdens het versturen van de aanvraag naar Arctic Manager. Fout is %s</string>
-    <string name="request_arctic_success">Aanvraag succesvol verstuurt naar Arctic Manager</string>
+    <string name="request_pacific_sending">Aanvraag versturen naar Pacific Manager...</string>
+    <string name="request_pacific_error">Fout tijdens het versturen van de aanvraag naar Pacific Manager. Fout is %s</string>
+    <string name="request_pacific_success">Aanvraag succesvol verstuurt naar Pacific Manager</string>
     <string name="request_fetching_data">Laatste gegevens ophalen…</string>
     <string name="request_build_failed">Kan pictogramaanvraag niet aanmaken</string>
     <string name="request_appfilter_failed">Kan appfilter.xml niet lezen</string>

--- a/library/src/main/res/values-pt-rBR/dashboard_strings.xml
+++ b/library/src/main/res/values-pt-rBR/dashboard_strings.xml
@@ -123,9 +123,9 @@
     <string name="request_not_requested">Não solicitado</string>
     <string name="request_already_requested">Já solicitado</string>
     <string name="request_building">Criando solicitação …</string>
-    <string name="request_arctic_sending">Enviando solicitação para Arctic Manager...</string>
-    <string name="request_arctic_error">Ocorreu um erro ao enviar a solicitação para o Arctic Manager. Erro é %s</string>
-    <string name="request_arctic_success">Pedido enviado com sucesso para Arctic Manager</string>
+    <string name="request_pacific_sending">Enviando solicitação para Pacific Manager...</string>
+    <string name="request_pacific_error">Ocorreu um erro ao enviar a solicitação para o Pacific Manager. Erro é %s</string>
+    <string name="request_pacific_success">Pedido enviado com sucesso para Pacific Manager</string>
     <string name="request_build_failed">Não foi possível criar a solicitação do ícone</string>
     <string name="request_appfilter_failed">Não foi possível ler appfilter.xml</string>
     <string name="request_requested">Por favor, verifique seu pedido novamente.

--- a/library/src/main/res/values-uk-rUA/dashboard_strings.xml
+++ b/library/src/main/res/values-uk-rUA/dashboard_strings.xml
@@ -126,9 +126,9 @@
     <string name="request_not_requested">Запит ще не надіслано</string>
     <string name="request_already_requested">Запит вже надіслано</string>
     <string name="request_building">Створення запиту …</string>
-    <string name="request_arctic_sending">Надсилання запиту до Arctic Manager...</string>
-    <string name="request_arctic_error">Сталася помилка під час надсилання запиту до Arctic Manager. Помилка %s</string>
-    <string name="request_arctic_success">Успішно надіслано запит до Arctic Manager</string>
+    <string name="request_pacific_sending">Надсилання запиту до Pacific Manager...</string>
+    <string name="request_pacific_error">Сталася помилка під час надсилання запиту до Pacific Manager. Помилка %s</string>
+    <string name="request_pacific_success">Успішно надіслано запит до Pacific Manager</string>
     <string name="request_fetching_data">Отримання останніх даних …</string>
     <string name="request_build_failed">Неможливо створити запит іконок</string>
     <string name="request_appfilter_failed">Неможливо прочитати appfilter.xml</string>

--- a/library/src/main/res/values/dashboard_configurations.xml
+++ b/library/src/main/res/values/dashboard_configurations.xml
@@ -185,9 +185,9 @@
         If you want to hide the information then you should enable this -->
     <bool name="hide_missing_app_count">false</bool>
 
-    <!-- Method to use for icon request. Value can be "email" or "arctic".
+    <!-- Method to use for icon request. Value can be "email" or "pacific".
         `email` -> Sends icon requests using email
-        `arctic` -> Sends icon requests using Arctic Manager
+        `pacific` -> Sends icon requests using Pacific Manager
 
         You can leave "premium_request_method" empty to use the regular request's method to send premium icon requests. -->
     <string name="regular_request_method"></string>
@@ -203,10 +203,10 @@
     <string name="regular_request_email_subject"></string>
     <string name="premium_request_email_subject"></string>
 
-    <!-- API keys for Arctic Manager.
-        You can leave "premium_request_arctic_api_key" empty to use the regular request's arctic api key to send premium icon requests. -->
-    <string name="regular_request_arctic_api_key"></string>
-    <string name="premium_request_arctic_api_key"></string>
+    <!-- API keys for Pacific Manager.
+        You can leave "premium_request_pacific_api_key" empty to use the regular request's pacific api key to send premium icon requests. -->
+    <string name="regular_request_pacific_api_key"></string>
+    <string name="premium_request_pacific_api_key"></string>
 
 
     <!--

--- a/library/src/main/res/values/dashboard_strings.xml
+++ b/library/src/main/res/values/dashboard_strings.xml
@@ -156,9 +156,9 @@
     <string name="request_already_requested">Already requested</string>
 
     <string name="request_building">Building request …</string>
-    <string name="request_arctic_sending">Sending request to Arctic Manager...</string>
-    <string name="request_arctic_error">Error occurred while sending request to Arctic Manager. Error is %s</string>
-    <string name="request_arctic_success">Successfully sent request to Arctic Manager</string>
+    <string name="request_pacific_sending">Sending request to Pacific Manager...</string>
+    <string name="request_pacific_error">Error occurred while sending request to Pacific Manager. Error is %s</string>
+    <string name="request_pacific_success">Successfully sent request to Pacific Manager</string>
     <string name="request_fetching_data">Fetching latest data …</string>
     <string name="request_build_failed">Unable to build icon request</string>
     <string name="request_appfilter_failed">Unable to read appfilter.xml</string>


### PR DESCRIPTION
Every instance of Arctic Manager has been replaced with Pacific Manager.

My plan is to stop Arctic within the upcoming 2 months, and I want to give users enough time to switch, without them getting errors. @sarsamurmu if you need a developer account on Pacific to test, feel free to send me a message.