### PR TITLE
Default config URL to app's PlayStore URL

### DIFF
--- a/library/src/main/java/candybar/lib/adapters/HomeAdapter.java
+++ b/library/src/main/java/candybar/lib/adapters/HomeAdapter.java
@@ -510,9 +510,14 @@ public class HomeAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
 
                     JSONObject configJson = new JSONObject(stringBuilder.toString());
                     latestVersion = configJson.getString("latestVersion");
-                    updateUrl = configJson.getString("url");
 
                     PackageInfo packageInfo = mContext.getPackageManager().getPackageInfo(mContext.getPackageName(), 0);
+                    if (configJson.isNull("url")) {
+                        // Default to Play Store
+                        updateUrl = "https://play.google.com/store/apps/details?id=" + packageInfo.packageName;
+                    } else {
+                        updateUrl = configJson.getString("url");
+                    }
                     long latestVersionCode = configJson.getLong("latestVersionCode");
                     long appVersionCode = Build.VERSION.SDK_INT >= Build.VERSION_CODES.P ? packageInfo.getLongVersionCode() : packageInfo.versionCode;
 

--- a/library/src/main/java/candybar/lib/fragments/RequestFragment.java
+++ b/library/src/main/java/candybar/lib/fragments/RequestFragment.java
@@ -577,14 +577,19 @@ public class RequestFragment extends Fragment implements View.OnClickListener {
                         stringBuilder.append(line);
                     }
 
+                    PackageInfo packageInfo = requireActivity().getPackageManager()
+                            .getPackageInfo(requireActivity().getPackageName(), 0);
                     JSONObject configJson = new JSONObject(stringBuilder.toString());
-                    updateUrl = configJson.getString("url");
+                    if (configJson.isNull("url")) {
+                        // Default to Play Store
+                        updateUrl = "https://play.google.com/store/apps/details?id=" + packageInfo.packageName;
+                    } else {
+                        updateUrl = configJson.getString("url");
+                    }
 
                     JSONObject disableRequestObj = configJson.getJSONObject("disableRequest");
                     long disableRequestBelow = disableRequestObj.optLong("below", 0);
                     String disableRequestOn = disableRequestObj.optString("on", "");
-                    PackageInfo packageInfo = requireActivity().getPackageManager()
-                            .getPackageInfo(requireActivity().getPackageName(), 0);
                     long appVersionCode = Build.VERSION.SDK_INT >= Build.VERSION_CODES.P
                             ? packageInfo.getLongVersionCode() : packageInfo.versionCode;
 


### PR DESCRIPTION
For flavoured builds, the URL for the Update button will differ and make
it necessary to manage the JSON and request configuration in multiple
JSON files instead of one.

As a sane default, this commit adds the package's Play Store URL in case
no URL is provided in the config.json. This means the change is fully
backwards-compatible.