### PR TITLE
Prevent exception when activity is destroyed

### DIFF
--- a/library/src/main/java/candybar/lib/activities/CandyBarMainActivity.java
+++ b/library/src/main/java/candybar/lib/activities/CandyBarMainActivity.java
@@ -97,6 +97,7 @@ import candybar.lib.preferences.Preferences;
 import candybar.lib.services.CandyBarService;
 import candybar.lib.tasks.IconRequestTask;
 import candybar.lib.tasks.IconsLoaderTask;
+import candybar.lib.utils.CandyBarGlideModule;
 import candybar.lib.utils.Extras;
 import candybar.lib.utils.InAppBillingClient;
 import candybar.lib.utils.listeners.InAppBillingListener;
@@ -793,14 +794,17 @@ public abstract class CandyBarMainActivity extends AppCompatActivity implements
             imageUrl = "drawable://" + DrawableHelper.getResourceId(this, imageUrl);
         }
 
-        Glide.with(this)
-                .load(imageUrl)
-                .override(720)
-                .optionalCenterInside()
-                .diskCacheStrategy(imageUrl.contains("drawable://")
-                        ? DiskCacheStrategy.NONE
-                        : DiskCacheStrategy.RESOURCE)
-                .into(image);
+        final Context context = this;
+        if (CandyBarGlideModule.isValidContextForGlide(context)) {
+            Glide.with(context)
+                    .load(imageUrl)
+                    .override(720)
+                    .optionalCenterInside()
+                    .diskCacheStrategy(imageUrl.contains("drawable://")
+                            ? DiskCacheStrategy.NONE
+                            : DiskCacheStrategy.RESOURCE)
+                    .into(image);
+        }
     }
 
     private void checkWallpapers() {

--- a/library/src/main/java/candybar/lib/adapters/AboutAdapter.java
+++ b/library/src/main/java/candybar/lib/adapters/AboutAdapter.java
@@ -41,6 +41,7 @@ import candybar.lib.fragments.dialog.CreditsFragment;
 import candybar.lib.fragments.dialog.LicensesFragment;
 import candybar.lib.helpers.ConfigurationHelper;
 import candybar.lib.preferences.Preferences;
+import candybar.lib.utils.CandyBarGlideModule;
 
 /*
  * CandyBar - Material Dashboard
@@ -141,14 +142,16 @@ public class AboutAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> 
                     imageUri = "drawable://" + DrawableHelper.getResourceId(mContext, imageUri);
                 }
 
-                Glide.with(mContext)
-                        .load(imageUri)
-                        .transition(DrawableTransitionOptions.withCrossFade(300))
-                        .skipMemoryCache(true)
-                        .diskCacheStrategy(imageUri.contains("drawable://")
-                                ? DiskCacheStrategy.NONE
-                                : DiskCacheStrategy.RESOURCE)
-                        .into(headerViewHolder.image);
+                if (CandyBarGlideModule.isValidContextForGlide(mContext)) {
+                    Glide.with(mContext)
+                            .load(imageUri)
+                            .transition(DrawableTransitionOptions.withCrossFade(300))
+                            .skipMemoryCache(true)
+                            .diskCacheStrategy(imageUri.contains("drawable://")
+                                    ? DiskCacheStrategy.NONE
+                                    : DiskCacheStrategy.RESOURCE)
+                            .into(headerViewHolder.image);
+                }
             }
 
             String profileUri = mContext.getResources().getString(R.string.about_profile_image);
@@ -156,13 +159,15 @@ public class AboutAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> 
                 profileUri = "drawable://" + DrawableHelper.getResourceId(mContext, profileUri);
             }
 
-            Glide.with(mContext)
-                    .load(profileUri)
-                    .skipMemoryCache(true)
-                    .diskCacheStrategy(profileUri.contains("drawable://")
-                            ? DiskCacheStrategy.NONE
-                            : DiskCacheStrategy.RESOURCE)
-                    .into(headerViewHolder.profile);
+            if (CandyBarGlideModule.isValidContextForGlide(mContext)) {
+                Glide.with(mContext)
+                        .load(profileUri)
+                        .skipMemoryCache(true)
+                        .diskCacheStrategy(profileUri.contains("drawable://")
+                                ? DiskCacheStrategy.NONE
+                                : DiskCacheStrategy.RESOURCE)
+                        .into(headerViewHolder.profile);
+            }
         }
     }
 

--- a/library/src/main/java/candybar/lib/adapters/HomeAdapter.java
+++ b/library/src/main/java/candybar/lib/adapters/HomeAdapter.java
@@ -72,6 +72,7 @@ import candybar.lib.helpers.WallpaperHelper;
 import candybar.lib.items.Home;
 import candybar.lib.preferences.Preferences;
 import candybar.lib.utils.AsyncTaskBase;
+import candybar.lib.utils.CandyBarGlideModule;
 import candybar.lib.utils.views.HeaderView;
 import me.grantland.widget.AutofitTextView;
 
@@ -221,14 +222,16 @@ public class HomeAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
                     uri = "drawable://" + DrawableHelper.getResourceId(mContext, uri);
                 }
 
-                Glide.with(mContext)
-                        .load(uri)
-                        .transition(DrawableTransitionOptions.withCrossFade(300))
-                        .skipMemoryCache(true)
-                        .diskCacheStrategy(uri.contains("drawable://")
-                                ? DiskCacheStrategy.NONE
-                                : DiskCacheStrategy.RESOURCE)
-                        .into(headerViewHolder.image);
+                if (CandyBarGlideModule.isValidContextForGlide(mContext)) {
+                    Glide.with(mContext)
+                            .load(uri)
+                            .transition(DrawableTransitionOptions.withCrossFade(300))
+                            .skipMemoryCache(true)
+                            .diskCacheStrategy(uri.contains("drawable://")
+                                    ? DiskCacheStrategy.NONE
+                                    : DiskCacheStrategy.RESOURCE)
+                            .into(headerViewHolder.image);
+                }
             }
         } else if (holder.getItemViewType() == TYPE_CONTENT) {
             ContentViewHolder contentViewHolder = (ContentViewHolder) holder;
@@ -237,32 +240,34 @@ public class HomeAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
             int color = ColorHelper.getAttributeColor(mContext, android.R.attr.textColorPrimary);
             if (mHomes.get(finalPosition).getIcon() != -1) {
                 if (mHomes.get(finalPosition).getType() == Home.Type.DIMENSION) {
-                    Glide.with(mContext)
-                            .asBitmap()
-                            .load("drawable://" + mHomes.get(finalPosition).getIcon())
-                            .skipMemoryCache(true)
-                            .diskCacheStrategy(DiskCacheStrategy.NONE)
-                            .listener(new RequestListener<Bitmap>() {
-                                @Override
-                                public boolean onLoadFailed(@Nullable GlideException e, Object model, Target<Bitmap> target, boolean isFirstResource) {
-                                    return true;
-                                }
+                    if (CandyBarGlideModule.isValidContextForGlide(mContext)) {
+                        Glide.with(mContext)
+                                .asBitmap()
+                                .load("drawable://" + mHomes.get(finalPosition).getIcon())
+                                .skipMemoryCache(true)
+                                .diskCacheStrategy(DiskCacheStrategy.NONE)
+                                .listener(new RequestListener<Bitmap>() {
+                                    @Override
+                                    public boolean onLoadFailed(@Nullable GlideException e, Object model, Target<Bitmap> target, boolean isFirstResource) {
+                                        return true;
+                                    }
 
-                                @Override
-                                public boolean onResourceReady(Bitmap bitmap, Object model, Target<Bitmap> target, DataSource dataSource, boolean isFirstResource) {
-                                    new Handler(Looper.getMainLooper()).post(() -> {
-                                        // Using RoundedBitmapDrawable because BitmapDrawable is deprecated
-                                        RoundedBitmapDrawable drawable = RoundedBitmapDrawableFactory.create(
-                                                mContext.getResources(), bitmap);
-                                        drawable.setCornerRadius(0);
-                                        contentViewHolder.title.setCompoundDrawablesWithIntrinsicBounds(
-                                                DrawableHelper.getResizedDrawable(mContext, drawable, 40),
-                                                null, null, null);
-                                    });
-                                    return true;
-                                }
-                            })
-                            .submit();
+                                    @Override
+                                    public boolean onResourceReady(Bitmap bitmap, Object model, Target<Bitmap> target, DataSource dataSource, boolean isFirstResource) {
+                                        new Handler(Looper.getMainLooper()).post(() -> {
+                                            // Using RoundedBitmapDrawable because BitmapDrawable is deprecated
+                                            RoundedBitmapDrawable drawable = RoundedBitmapDrawableFactory.create(
+                                                    mContext.getResources(), bitmap);
+                                            drawable.setCornerRadius(0);
+                                            contentViewHolder.title.setCompoundDrawablesWithIntrinsicBounds(
+                                                    DrawableHelper.getResizedDrawable(mContext, drawable, 40),
+                                                    null, null, null);
+                                        });
+                                        return true;
+                                    }
+                                })
+                                .submit();
+                    }
                 } else {
                     contentViewHolder.title.setCompoundDrawablesWithIntrinsicBounds(DrawableHelper.getTintedDrawable(
                             mContext, mHomes.get(finalPosition).getIcon(), color), null, null, null);

--- a/library/src/main/java/candybar/lib/adapters/LauncherAdapter.java
+++ b/library/src/main/java/candybar/lib/adapters/LauncherAdapter.java
@@ -23,6 +23,7 @@ import candybar.lib.R;
 import candybar.lib.helpers.LauncherHelper;
 import candybar.lib.items.Icon;
 import candybar.lib.preferences.Preferences;
+import candybar.lib.utils.CandyBarGlideModule;
 
 /*
  * CandyBar - Material Dashboard
@@ -83,13 +84,15 @@ public class LauncherAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolde
             ViewHolder contentViewHolder = ((ViewHolder) holder);
             contentViewHolder.name.setText(mLaunchers.get(position).getTitle());
 
-            Glide.with(mContext)
-                    .asBitmap()
-                    .load("drawable://" + mLaunchers.get(position).getRes())
-                    .transition(BitmapTransitionOptions.withCrossFade(300))
-                    .skipMemoryCache(true)
-                    .diskCacheStrategy(DiskCacheStrategy.NONE)
-                    .into(contentViewHolder.icon);
+            if (CandyBarGlideModule.isValidContextForGlide(mContext)) {
+                Glide.with(mContext)
+                        .asBitmap()
+                        .load("drawable://" + mLaunchers.get(position).getRes())
+                        .transition(BitmapTransitionOptions.withCrossFade(300))
+                        .skipMemoryCache(true)
+                        .diskCacheStrategy(DiskCacheStrategy.NONE)
+                        .into(contentViewHolder.icon);
+            }
         }
     }
 

--- a/library/src/main/java/candybar/lib/adapters/PresetsAdapter.java
+++ b/library/src/main/java/candybar/lib/adapters/PresetsAdapter.java
@@ -43,6 +43,7 @@ import candybar.lib.applications.CandyBarApplication;
 import candybar.lib.helpers.TypefaceHelper;
 import candybar.lib.items.Preset;
 import candybar.lib.preferences.Preferences;
+import candybar.lib.utils.CandyBarGlideModule;
 import candybar.lib.utils.views.HeaderView;
 
 /*
@@ -107,13 +108,15 @@ public class PresetsAdapter extends RecyclerView.Adapter<PresetsAdapter.ViewHold
             PresetInfoLoader.create(new AssetPresetFile(preset.getPath()))
                     .load(mContext, info -> holder.name.setText(info.getTitle()));
 
-            Glide.with(mContext)
-                    .asBitmap()
-                    .load(new AssetPresetFile(preset.getPath()))
-                    .transition(BitmapTransitionOptions.withCrossFade(300))
-                    .skipMemoryCache(true)
-                    .diskCacheStrategy(DiskCacheStrategy.NONE)
-                    .into(holder.image);
+            if (CandyBarGlideModule.isValidContextForGlide(mContext)) {
+                Glide.with(mContext)
+                        .asBitmap()
+                        .load(new AssetPresetFile(preset.getPath()))
+                        .transition(BitmapTransitionOptions.withCrossFade(300))
+                        .skipMemoryCache(true)
+                        .diskCacheStrategy(DiskCacheStrategy.NONE)
+                        .into(holder.image);
+            }
         }
     }
 

--- a/library/src/main/java/candybar/lib/adapters/RequestAdapter.java
+++ b/library/src/main/java/candybar/lib/adapters/RequestAdapter.java
@@ -35,6 +35,7 @@ import candybar.lib.R;
 import candybar.lib.applications.CandyBarApplication;
 import candybar.lib.items.Request;
 import candybar.lib.preferences.Preferences;
+import candybar.lib.utils.CandyBarGlideModule;
 import candybar.lib.utils.listeners.RequestListener;
 
 /*
@@ -182,12 +183,14 @@ public class RequestAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder
             int finalPosition = mShowPremiumRequest ? position - 1 : position;
             ContentViewHolder contentViewHolder = (ContentViewHolder) holder;
 
-            Glide.with(mContext)
-                    .load("package://" + mRequests.get(finalPosition).getActivity())
-                    .override(272)
-                    .transition(DrawableTransitionOptions.withCrossFade(300))
-                    .diskCacheStrategy(DiskCacheStrategy.NONE)
-                    .into(contentViewHolder.icon);
+            if (CandyBarGlideModule.isValidContextForGlide(mContext)) {
+                Glide.with(mContext)
+                        .load("package://" + mRequests.get(finalPosition).getActivity())
+                        .override(272)
+                        .transition(DrawableTransitionOptions.withCrossFade(300))
+                        .diskCacheStrategy(DiskCacheStrategy.NONE)
+                        .into(contentViewHolder.icon);
+            }
 
             contentViewHolder.title.setText(mRequests.get(finalPosition).getName());
 

--- a/library/src/main/java/candybar/lib/adapters/WallpapersAdapter.java
+++ b/library/src/main/java/candybar/lib/adapters/WallpapersAdapter.java
@@ -39,6 +39,7 @@ import candybar.lib.items.PopupItem;
 import candybar.lib.items.Wallpaper;
 import candybar.lib.preferences.Preferences;
 import candybar.lib.tasks.WallpaperApplyTask;
+import candybar.lib.utils.CandyBarGlideModule;
 import candybar.lib.utils.Extras;
 import candybar.lib.utils.ImageConfig;
 import candybar.lib.utils.Popup;
@@ -101,25 +102,27 @@ public class WallpapersAdapter extends RecyclerView.Adapter<WallpapersAdapter.Vi
             holder.author.setText(wallpaper.getAuthor());
         }
 
-        Glide.with(mContext)
-                .asBitmap()
-                .load(wallpaper.getThumbUrl())
-                .override(ImageConfig.getThumbnailSize())
-                .transition(BitmapTransitionOptions.withCrossFade(300))
-                .diskCacheStrategy(DiskCacheStrategy.RESOURCE)
-                .listener(new RequestListener<Bitmap>() {
-                    @Override
-                    public boolean onLoadFailed(@Nullable GlideException e, Object model, Target<Bitmap> target, boolean isFirstResource) {
-                        return false;
-                    }
+        if (CandyBarGlideModule.isValidContextForGlide(mContext)) {
+            Glide.with(mContext)
+                    .asBitmap()
+                    .load(wallpaper.getThumbUrl())
+                    .override(ImageConfig.getThumbnailSize())
+                    .transition(BitmapTransitionOptions.withCrossFade(300))
+                    .diskCacheStrategy(DiskCacheStrategy.RESOURCE)
+                    .listener(new RequestListener<Bitmap>() {
+                        @Override
+                        public boolean onLoadFailed(@Nullable GlideException e, Object model, Target<Bitmap> target, boolean isFirstResource) {
+                            return false;
+                        }
 
-                    @Override
-                    public boolean onResourceReady(Bitmap resource, Object model, Target<Bitmap> target, DataSource dataSource, boolean isFirstResource) {
-                        holder.thumbnailBitmap = resource;
-                        return false;
-                    }
-                })
-                .into(holder.image);
+                        @Override
+                        public boolean onResourceReady(Bitmap resource, Object model, Target<Bitmap> target, DataSource dataSource, boolean isFirstResource) {
+                            holder.thumbnailBitmap = resource;
+                            return false;
+                        }
+                    })
+                    .into(holder.image);
+        }
     }
 
     public void search(String string) {

--- a/library/src/main/java/candybar/lib/adapters/dialog/CreditsAdapter.java
+++ b/library/src/main/java/candybar/lib/adapters/dialog/CreditsAdapter.java
@@ -28,6 +28,7 @@ import java.util.List;
 
 import candybar.lib.R;
 import candybar.lib.items.Credit;
+import candybar.lib.utils.CandyBarGlideModule;
 
 /*
  * CandyBar - Material Dashboard
@@ -108,16 +109,18 @@ public class CreditsAdapter extends BaseAdapter {
             holder.subtitle.setVisibility(View.VISIBLE);
         }
 
-        Glide.with(mContext)
-                .load(credit.getImage())
-                .override(144)
-                .optionalCenterInside()
-                .circleCrop()
-                .placeholder(mPlaceholder)
-                .transition(DrawableTransitionOptions.withCrossFade(300))
-                .skipMemoryCache(true)
-                .diskCacheStrategy(DiskCacheStrategy.RESOURCE)
-                .into(holder.image);
+        if (CandyBarGlideModule.isValidContextForGlide(mContext)) {
+            Glide.with(mContext)
+                    .load(credit.getImage())
+                    .override(144)
+                    .optionalCenterInside()
+                    .circleCrop()
+                    .placeholder(mPlaceholder)
+                    .transition(DrawableTransitionOptions.withCrossFade(300))
+                    .skipMemoryCache(true)
+                    .diskCacheStrategy(DiskCacheStrategy.RESOURCE)
+                    .into(holder.image);
+        }
 
         return view;
     }

--- a/library/src/main/java/candybar/lib/adapters/dialog/OtherAppsAdapter.java
+++ b/library/src/main/java/candybar/lib/adapters/dialog/OtherAppsAdapter.java
@@ -25,6 +25,7 @@ import java.util.List;
 
 import candybar.lib.R;
 import candybar.lib.applications.CandyBarApplication;
+import candybar.lib.utils.CandyBarGlideModule;
 
 /*
  * CandyBar - Material Dashboard
@@ -86,14 +87,16 @@ public class OtherAppsAdapter extends BaseAdapter {
             uri = "drawable://" + DrawableHelper.getResourceId(mContext, uri);
         }
 
-        Glide.with(mContext)
-                .load(uri)
-                .transition(DrawableTransitionOptions.withCrossFade(300))
-                .skipMemoryCache(true)
-                .diskCacheStrategy(uri.contains("drawable://")
-                        ? DiskCacheStrategy.NONE
-                        : DiskCacheStrategy.RESOURCE)
-                .into(holder.image);
+        if (CandyBarGlideModule.isValidContextForGlide(mContext)) {
+            Glide.with(mContext)
+                    .load(uri)
+                    .transition(DrawableTransitionOptions.withCrossFade(300))
+                    .skipMemoryCache(true)
+                    .diskCacheStrategy(uri.contains("drawable://")
+                            ? DiskCacheStrategy.NONE
+                            : DiskCacheStrategy.RESOURCE)
+                    .into(holder.image);
+        }
 
         holder.title.setText(otherApp.getTitle());
 

--- a/library/src/main/java/candybar/lib/helpers/IconsHelper.java
+++ b/library/src/main/java/candybar/lib/helpers/IconsHelper.java
@@ -34,6 +34,7 @@ import candybar.lib.activities.CandyBarMainActivity;
 import candybar.lib.applications.CandyBarApplication;
 import candybar.lib.fragments.dialog.IconPreviewFragment;
 import candybar.lib.items.Icon;
+import candybar.lib.utils.CandyBarGlideModule;
 
 import static candybar.lib.helpers.DrawableHelper.getRightIcon;
 import static com.danimahardhika.android.helpers.core.DrawableHelper.getResourceId;
@@ -169,7 +170,7 @@ public class IconsHelper {
     }
 
     public static void selectIcon(@NonNull Context context, int action, Icon icon) {
-        if (action == IntentHelper.ICON_PICKER) {
+        if (action == IntentHelper.ICON_PICKER && CandyBarGlideModule.isValidContextForGlide(context)) {
             Glide.with(context)
                     .asBitmap()
                     .load("drawable://" + icon.getRes())
@@ -197,7 +198,7 @@ public class IconsHelper {
                         }
                     })
                     .submit();
-        } else if (action == IntentHelper.IMAGE_PICKER) {
+        } else if (action == IntentHelper.IMAGE_PICKER && CandyBarGlideModule.isValidContextForGlide(context)) {
 
             Glide.with(context)
                     .asBitmap()

--- a/library/src/main/java/candybar/lib/utils/CandyBarGlideModule.java
+++ b/library/src/main/java/candybar/lib/utils/CandyBarGlideModule.java
@@ -1,7 +1,9 @@
 package candybar.lib.utils;
 
+import android.app.Activity;
 import android.content.Context;
 import android.graphics.Bitmap;
+import android.os.Build;
 
 import androidx.annotation.NonNull;
 
@@ -15,5 +17,22 @@ public final class CandyBarGlideModule extends AppGlideModule {
     @Override
     public void registerComponents(@NonNull Context context, @NonNull Glide glide, Registry registry) {
         registry.prepend(String.class, Bitmap.class, new CommonModelLoaderFactory(context));
+    }
+
+    // Kindly provided by @farhan on GitHub
+    // https://github.com/bumptech/glide/issues/1484#issuecomment-365625087
+    public static boolean isValidContextForGlide(final Context context) {
+        if (context == null) {
+            return false;
+        }
+        if (context instanceof Activity) {
+            final Activity activity = (Activity) context;
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
+                return !activity.isDestroyed() && !activity.isFinishing();
+            } else {
+                return !activity.isFinishing();
+            }
+        }
+        return true;
     }
 }


### PR DESCRIPTION
When a user taps the back button or otherwise triggers the activity to
be destroyed, this would lead to an exception in Glider, force-closing
the app with:

```
Fatal Exception: java.lang.IllegalArgumentException: You cannot start a load for a destroyed activity
       at com.bumptech.glide.manager.RequestManagerRetriever.assertNotDestroyed(RequestManagerRetriever.java:317)
       at com.bumptech.glide.manager.RequestManagerRetriever.get(RequestManagerRetriever.java:128)
       at com.bumptech.glide.Glide.with(Glide.java:801)
...
```

When the activity is destroyed, it's pointless trying to load the
resource anyway, so this commit wraps calls to Glider with an according
check. The solution was taken from a discussion[1] on GitHub.

[1] https://github.com/bumptech/glide/issues/1484#issuecomment-365625087