### PR TITLE
Fix keyboard not showing in search (API 31+)

### DIFF
--- a/library/src/main/res/layout/search_bar.xml
+++ b/library/src/main/res/layout/search_bar.xml
@@ -22,7 +22,9 @@
         android:maxWidth="250dp"
         android:layout_alignParentLeft="true"
         android:layout_toLeftOf="@id/clear_query_button"
-        app:fontFamily="@font/regular" />
+        app:fontFamily="@font/regular">
+        <requestFocus />
+    </EditText>
 
     <ImageButton
         android:id="@+id/clear_query_button"


### PR DESCRIPTION
This commit adds a tag for requesting focus on the icon search input field which fixes the issue of the keyboard not displaying in API versions 31 and above.

Verified with Candybar 3.15.0 via an emulated Pixel XL (API 31)

Fixes #84