### PR TITLE
Fixed GMail(2022.10.02) not sending Icon Request

### DIFF
--- a/library/src/main/java/candybar/lib/tasks/IconRequestBuilderTask.java
+++ b/library/src/main/java/candybar/lib/tasks/IconRequestBuilderTask.java
@@ -172,7 +172,7 @@ public class IconRequestBuilderTask extends AsyncTaskBase {
             Intent intent = new Intent(Intent.ACTION_SEND);
             addIntentExtra(intent, emailBody);
             intent.setComponent(name);
-            intent.addCategory(Intent.CATEGORY_LAUNCHER);
+            if (android.os.Build.VERSION.SDK_INT < 32) { intent.addCategory(Intent.CATEGORY_LAUNCHER); }
             intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
             return intent;
         } catch (IllegalArgumentException e) {


### PR DESCRIPTION
This commit uses the recommended change from https://github.com/zixpo/candybar/issues/97 to fix GMail not sending Icon Requests but instead instantly closing. Fixes #97