### PR TITLE
Fix clock widget click on Android 12

### DIFF
--- a/library/src/main/java/candybar/lib/services/CandyBarWidgetService.java
+++ b/library/src/main/java/candybar/lib/services/CandyBarWidgetService.java
@@ -15,13 +15,23 @@ public class CandyBarWidgetService extends AppWidgetProvider {
 
     public void onReceive(Context context, Intent intent) {
         String act = intent.getAction();
+        int flags;
+
         if (AppWidgetManager.ACTION_APPWIDGET_UPDATE.equals(act)) {
             RemoteViews clockView = new RemoteViews(context.getPackageName(), R.layout.analog_clock);
 
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
                 Intent clockIntent = new Intent(AlarmClock.ACTION_SHOW_ALARMS);
                 clockIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-                clockView.setOnClickPendingIntent(R.id.analog_clock, PendingIntent.getActivity(context, 0, clockIntent, 0));
+
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                    flags = PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE;
+                }
+                else {
+                    flags = 0;
+                }
+
+                clockView.setOnClickPendingIntent(R.id.analog_clock, PendingIntent.getActivity(context, 0, clockIntent, flags));
             }
 
             AppWidgetManager.getInstance(context).updateAppWidget(intent.getIntArrayExtra(AppWidgetManager.EXTRA_APPWIDGET_IDS), clockView);


### PR DESCRIPTION
A mutability flag must be set on Android 12

from: https://github.com/Donnnno/candybar-foss/pull/6 with credits to @kaanelloed !

fixes: https://github.com/zixpo/candybar/issues/81
