### PR TITLE
Only show dialog if activity is alive

### DIFF
--- a/library/src/main/java/candybar/lib/helpers/LicenseCallbackHelper.java
+++ b/library/src/main/java/candybar/lib/helpers/LicenseCallbackHelper.java
@@ -1,5 +1,6 @@
 package candybar.lib.helpers;
 
+import android.app.Activity;
 import android.content.Context;
 import android.os.Handler;
 import android.os.Looper;
@@ -53,7 +54,9 @@ public class LicenseCallbackHelper implements LicenseCallback {
 
     @Override
     public void onLicenseCheckStart() {
-        mDialog.show();
+        if (!((Activity) mContext).isFinishing() && !((Activity) mContext).isDestroyed()) {
+            mDialog.show();
+        }
     }
 
     @Override
@@ -62,14 +65,16 @@ public class LicenseCallbackHelper implements LicenseCallback {
         // and it messes up the layout, so delay is the workaround
 
         new Handler(Looper.getMainLooper()).postDelayed(() -> {
-            mDialog.dismiss();
+            if (!((Activity) mContext).isFinishing() && !((Activity) mContext).isDestroyed()) {
+                mDialog.dismiss();
 
-            if (status == LicenseHelper.Status.RETRY) {
-                showRetryDialog();
-                return;
+                if (status == LicenseHelper.Status.RETRY) {
+                    showRetryDialog();
+                    return;
+                }
+
+                showLicenseDialog(status);
             }
-
-            showLicenseDialog(status);
         }, 1000);
     }
 

--- a/library/src/main/java/candybar/lib/tasks/WallpaperApplyTask.java
+++ b/library/src/main/java/candybar/lib/tasks/WallpaperApplyTask.java
@@ -353,7 +353,7 @@ public class WallpaperApplyTask extends AsyncTaskBase implements WallpaperProper
             return;
         }
 
-        if (((AppCompatActivity) mContext.get()).isFinishing()) {
+        if (((AppCompatActivity) mContext.get()).isFinishing() || ((AppCompatActivity) mContext.get()).isDestroyed()) {
             return;
         }
 


### PR DESCRIPTION
I keep receiving crash reports via Firebase Crashlytics (~2 per week) like the ones below. They both point to possibly dialogs being shown when the main activity is no longer around. This commit adds a safety guard around displaying the license check dialog.

```
Fatal Exception: java.lang.IllegalArgumentException: View=DecorView@6a8de17[MainActivity] not attached to window manager
       at android.view.WindowManagerGlobal.findViewLocked(WindowManagerGlobal.java:707)
       at android.view.WindowManagerGlobal.removeView(WindowManagerGlobal.java:593)
       at android.view.WindowManagerImpl.removeViewImmediate(WindowManagerImpl.java:206)
       at android.app.Dialog.dismissDialog(Dialog.java:813)
       at android.app.Dialog.dismiss(Dialog.java:795)
       at com.afollestad.materialdialogs.MaterialDialog.dismiss(MaterialDialog.java:993)
       at candybar.lib.helpers.LicenseCallbackHelper.lambda$onLicenseCheckFinished$0(LicenseCallbackHelper.java:65)
       at candybar.lib.helpers.LicenseCallbackHelper.$r8$lambda$ejgT_oTVO_0gVEIP2rk2W7Bu10A(LicenseCallbackHelper.java)
       at candybar.lib.helpers.LicenseCallbackHelper$$InternalSyntheticLambda$3$b400bb4b38f3f8ecb1fa25cb5413fb5867117f5619d88579225385843512a5b0$0.run(LicenseCallbackHelper.java:4)
       at android.os.Handler.handleCallback(Handler.java:942)
       at android.os.Handler.dispatchMessage(Handler.java:99)
       at android.os.Looper.loopOnce(Looper.java:226)
       at android.os.Looper.loop(Looper.java:313)
       at android.app.ActivityThread.main(ActivityThread.java:8741)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:571)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1067)
```

```
Fatal Exception: o.t41$e: Bad window token, you cannot show a dialog before an Activity is created or after it's hidden.
       at com.afollestad.materialdialogs.MaterialDialog.show(MaterialDialog.java:466)
       at com.afollestad.materialdialogs.MaterialDialog$Builder.show(MaterialDialog.java:2189)
       at candybar.lib.helpers.LicenseCallbackHelper.showLicenseDialog(LicenseCallbackHelper.java:90)
       at candybar.lib.helpers.LicenseCallbackHelper.lambda$onLicenseCheckFinished$0(LicenseCallbackHelper.java:72)
       at candybar.lib.helpers.LicenseCallbackHelper.$r8$lambda$ejgT_oTVO_0gVEIP2rk2W7Bu10A(LicenseCallbackHelper.java)
       at candybar.lib.helpers.LicenseCallbackHelper$$InternalSyntheticLambda$3$b400bb4b38f3f8ecb1fa25cb5413fb5867117f5619d88579225385843512a5b0$0.run(LicenseCallbackHelper.java:4)
       at android.os.Handler.handleCallback(Handler.java:938)
       at android.os.Handler.dispatchMessage(Handler.java:99)
       at android.os.Looper.loop(Looper.java:233)
       at android.app.ActivityThread.main(ActivityThread.java:8068)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:631)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:978)
```

Might fix #103 