### PR TITLE
Prevent crash when not attached to activity

### DIFF
--- a/library/src/main/java/candybar/lib/fragments/IconsFragment.java
+++ b/library/src/main/java/candybar/lib/fragments/IconsFragment.java
@@ -148,7 +148,7 @@ public class IconsFragment extends Fragment {
     }
 
     public void refreshBookmarks() {
-        if (isBookmarksFragment) {
+        if (isBookmarksFragment && isAdded()) {
             mIcons = Database.get(requireActivity()).getBookmarkedIcons(requireActivity());
             mAdapter.setIcons(mIcons);
             setupViewVisibility();


### PR DESCRIPTION
An exception would be logged every so often when the bookmark dialog is dismissed but at the same time the IconFragment is no longer attached to an activity. This commit adds an additional check with isAdded() to make sure the fragment is attached to an activity.