### PR TITLE
Support basic analytics for views and clicks

### DIFF
--- a/library/src/main/java/candybar/lib/activities/CandyBarWallpaperActivity.java
+++ b/library/src/main/java/candybar/lib/activities/CandyBarWallpaperActivity.java
@@ -98,6 +98,7 @@ public class CandyBarWallpaperActivity extends AppCompatActivity implements View
     private boolean mIsResumed = false;
 
     private Wallpaper mWallpaper;
+    private String mWallpaperName;
     private Runnable mRunnable;
     private Handler mHandler;
     private PhotoViewAttacher mAttacher;
@@ -143,10 +144,13 @@ public class CandyBarWallpaperActivity extends AppCompatActivity implements View
             finish();
             return;
         }
+
+        mWallpaperName = mWallpaper.getURL().split("/")[mWallpaper.getURL().split("/").length-1];
+
         CandyBarApplication.getConfiguration().getAnalyticsHandler().logEvent(
                 "wallpaper",
                 new HashMap<String, Object>() {{
-                    put("url", mWallpaper.getURL());
+                    put("url", mWallpaperName);
                     put("action", "preview");
                 }}
         );
@@ -320,7 +324,7 @@ public class CandyBarWallpaperActivity extends AppCompatActivity implements View
                                 CandyBarApplication.getConfiguration().getAnalyticsHandler().logEvent(
                                         "wallpaper",
                                         new HashMap<String, Object>() {{
-                                            put("url", mWallpaper.getURL());
+                                            put("url", mWallpaperName);
                                             put("section", "lockscreen");
                                             put("action", "apply");
                                         }}
@@ -330,7 +334,7 @@ public class CandyBarWallpaperActivity extends AppCompatActivity implements View
                                 CandyBarApplication.getConfiguration().getAnalyticsHandler().logEvent(
                                         "wallpaper",
                                         new HashMap<String, Object>() {{
-                                            put("url", mWallpaper.getURL());
+                                            put("url", mWallpaperName);
                                             put("section", "homescreen");
                                             put("action", "apply");
                                         }}
@@ -340,7 +344,7 @@ public class CandyBarWallpaperActivity extends AppCompatActivity implements View
                                 CandyBarApplication.getConfiguration().getAnalyticsHandler().logEvent(
                                         "wallpaper",
                                         new HashMap<String, Object>() {{
-                                            put("url", mWallpaper.getURL());
+                                            put("url", mWallpaperName);
                                             put("section", "homescreen_and_lockscreen");
                                             put("action", "apply");
                                         }}

--- a/library/src/main/java/candybar/lib/activities/CandyBarWallpaperActivity.java
+++ b/library/src/main/java/candybar/lib/activities/CandyBarWallpaperActivity.java
@@ -44,8 +44,11 @@ import com.danimahardhika.android.helpers.permission.PermissionCode;
 import com.kogitune.activitytransition.ActivityTransition;
 import com.kogitune.activitytransition.ExitActivityTransition;
 
+import java.util.HashMap;
+
 import candybar.lib.R;
 import candybar.lib.adapters.WallpapersAdapter;
+import candybar.lib.applications.CandyBarApplication;
 import candybar.lib.databases.Database;
 import candybar.lib.helpers.LocaleHelper;
 import candybar.lib.helpers.TapIntroHelper;
@@ -140,6 +143,13 @@ public class CandyBarWallpaperActivity extends AppCompatActivity implements View
             finish();
             return;
         }
+        CandyBarApplication.getConfiguration().getAnalyticsHandler().logEvent(
+                "wallpaper",
+                new HashMap<String, Object>() {{
+                    put("url", mWallpaper.getURL());
+                    put("action", "preview");
+                }}
+        );
 
         initBottomBar();
         resetBottomBarPadding();
@@ -307,10 +317,34 @@ public class CandyBarWallpaperActivity extends AppCompatActivity implements View
                                     .crop(rectF);
 
                             if (item.getType() == PopupItem.Type.LOCKSCREEN) {
+                                CandyBarApplication.getConfiguration().getAnalyticsHandler().logEvent(
+                                        "wallpaper",
+                                        new HashMap<String, Object>() {{
+                                            put("url", mWallpaper.getURL());
+                                            put("section", "lockscreen");
+                                            put("action", "apply");
+                                        }}
+                                );
                                 task.to(WallpaperApplyTask.Apply.LOCKSCREEN);
                             } else if (item.getType() == PopupItem.Type.HOMESCREEN) {
+                                CandyBarApplication.getConfiguration().getAnalyticsHandler().logEvent(
+                                        "wallpaper",
+                                        new HashMap<String, Object>() {{
+                                            put("url", mWallpaper.getURL());
+                                            put("section", "homescreen");
+                                            put("action", "apply");
+                                        }}
+                                );
                                 task.to(WallpaperApplyTask.Apply.HOMESCREEN);
                             } else if (item.getType() == PopupItem.Type.HOMESCREEN_LOCKSCREEN) {
+                                CandyBarApplication.getConfiguration().getAnalyticsHandler().logEvent(
+                                        "wallpaper",
+                                        new HashMap<String, Object>() {{
+                                            put("url", mWallpaper.getURL());
+                                            put("section", "homescreen_and_lockscreen");
+                                            put("action", "apply");
+                                        }}
+                                );
                                 task.to(WallpaperApplyTask.Apply.HOMESCREEN_LOCKSCREEN);
                             }
 

--- a/library/src/main/java/candybar/lib/adapters/AboutAdapter.java
+++ b/library/src/main/java/candybar/lib/adapters/AboutAdapter.java
@@ -34,6 +34,8 @@ import com.danimahardhika.android.helpers.core.utils.LogUtil;
 import com.google.android.material.card.MaterialCardView;
 import com.mikhaellopez.circularimageview.CircularImageView;
 
+import java.util.HashMap;
+
 import candybar.lib.BuildConfig;
 import candybar.lib.R;
 import candybar.lib.applications.CandyBarApplication;
@@ -337,13 +339,37 @@ public class AboutAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> 
         public void onClick(View view) {
             int id = view.getId();
             if (id == R.id.contributors_title) {
+                CandyBarApplication.getConfiguration().getAnalyticsHandler().logEvent(
+                        "click",
+                        new HashMap<String, Object>() {{
+                            put("section", "about");
+                            put("action", "open_dialog");
+                            put("item", "contributors");
+                        }}
+                );
                 CreditsFragment.showCreditsDialog(((AppCompatActivity) mContext).getSupportFragmentManager(),
                         CreditsFragment.TYPE_ICON_PACK_CONTRIBUTORS);
             } else if (id == R.id.privacy_policy_title) {
+                CandyBarApplication.getConfiguration().getAnalyticsHandler().logEvent(
+                        "click",
+                        new HashMap<String, Object>() {{
+                            put("section", "about");
+                            put("action", "open_dialog");
+                            put("item", "privacy_policy");
+                        }}
+                );
                 Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(mContext.getResources().getString(R.string.privacy_policy_link)));
                 intent.addFlags(Intent.FLAG_ACTIVITY_BROUGHT_TO_FRONT);
                 mContext.startActivity(intent);
             } else if (id == R.id.terms_title) {
+                CandyBarApplication.getConfiguration().getAnalyticsHandler().logEvent(
+                        "click",
+                        new HashMap<String, Object>() {{
+                            put("section", "about");
+                            put("action", "open_dialog");
+                            put("item", "terms_and_conditions");
+                        }}
+                );
                 Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(mContext.getResources().getString(R.string.terms_and_conditions_link)));
                 intent.addFlags(Intent.FLAG_ACTIVITY_BROUGHT_TO_FRONT);
                 mContext.startActivity(intent);
@@ -411,17 +437,41 @@ public class AboutAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> 
         public void onClick(View view) {
             int id = view.getId();
             if (id == R.id.about_dashboard_licenses) {
+                CandyBarApplication.getConfiguration().getAnalyticsHandler().logEvent(
+                        "click",
+                        new HashMap<String, Object>() {{
+                            put("section", "about");
+                            put("action", "open_dialog");
+                            put("item", "licenses");
+                        }}
+                );
                 LicensesFragment.showLicensesDialog(((AppCompatActivity) mContext).getSupportFragmentManager());
                 return;
             }
 
             if (id == R.id.about_dashboard_contributors) {
+                CandyBarApplication.getConfiguration().getAnalyticsHandler().logEvent(
+                        "click",
+                        new HashMap<String, Object>() {{
+                            put("section", "about");
+                            put("action", "open_dialog");
+                            put("item", "contributors");
+                        }}
+                );
                 CreditsFragment.showCreditsDialog(((AppCompatActivity) mContext).getSupportFragmentManager(),
                         CreditsFragment.TYPE_DASHBOARD_CONTRIBUTORS);
                 return;
             }
 
             if (id == R.id.about_dashboard_translator) {
+                CandyBarApplication.getConfiguration().getAnalyticsHandler().logEvent(
+                        "click",
+                        new HashMap<String, Object>() {{
+                            put("section", "about");
+                            put("action", "open_dialog");
+                            put("item", "translators");
+                        }}
+                );
                 CreditsFragment.showCreditsDialog(((AppCompatActivity) mContext).getSupportFragmentManager(),
                         CreditsFragment.TYPE_DASHBOARD_TRANSLATOR);
                 return;
@@ -429,6 +479,14 @@ public class AboutAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> 
 
             Intent intent = null;
             if (id == R.id.about_dashboard_github) {
+                CandyBarApplication.getConfiguration().getAnalyticsHandler().logEvent(
+                        "click",
+                        new HashMap<String, Object>() {{
+                            put("section", "about");
+                            put("action", "open_dialog");
+                            put("item", "github");
+                        }}
+                );
                 intent = new Intent(Intent.ACTION_VIEW, Uri.parse(mContext
                         .getResources().getString(R.string.about_dashboard_github_url)));
             }

--- a/library/src/main/java/candybar/lib/adapters/AboutSocialAdapter.java
+++ b/library/src/main/java/candybar/lib/adapters/AboutSocialAdapter.java
@@ -16,6 +16,8 @@ import androidx.recyclerview.widget.RecyclerView;
 
 import com.danimahardhika.android.helpers.core.utils.LogUtil;
 
+import java.util.HashMap;
+
 import candybar.lib.R;
 import candybar.lib.applications.CandyBarApplication;
 import candybar.lib.helpers.UrlHelper;
@@ -97,6 +99,14 @@ public class AboutSocialAdapter extends RecyclerView.Adapter<RecyclerView.ViewHo
             int position = getBindingAdapterPosition();
             if (position < 0 || position > mUrls.length) return;
 
+            CandyBarApplication.getConfiguration().getAnalyticsHandler().logEvent(
+                    "click",
+                    new HashMap<String, Object>() {{
+                        put("section", "about");
+                        put("action", "open_social");
+                        put("url", mUrls[position]);
+                    }}
+            );
             if (id == R.id.image) {
                 UrlHelper.Type type = UrlHelper.getType(mUrls[position]);
                 if (type == UrlHelper.Type.INVALID) return;

--- a/library/src/main/java/candybar/lib/adapters/FAQsAdapter.java
+++ b/library/src/main/java/candybar/lib/adapters/FAQsAdapter.java
@@ -10,10 +10,12 @@ import androidx.annotation.NonNull;
 import androidx.recyclerview.widget.RecyclerView;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 
 import candybar.lib.R;
+import candybar.lib.applications.CandyBarApplication;
 import candybar.lib.items.FAQs;
 import candybar.lib.preferences.Preferences;
 
@@ -135,6 +137,28 @@ public class FAQsAdapter extends RecyclerView.Adapter<FAQsAdapter.ViewHolder> {
                     mFAQs.add(faq);
                 }
             }
+        }
+        if (getFaqsCount() == 0) {
+            CandyBarApplication.getConfiguration().getAnalyticsHandler().logEvent(
+                    "type",
+                    new HashMap<String, Object>() {{
+                        put("section", "faq");
+                        put("action", "search");
+                        put("found", "no");
+                        put("query", query);
+                    }}
+            );
+        } else {
+            CandyBarApplication.getConfiguration().getAnalyticsHandler().logEvent(
+                    "type",
+                    new HashMap<String, Object>() {{
+                        put("section", "faq");
+                        put("action", "search");
+                        put("found", "yes");
+                        put("query", query);
+                        put("num_results", getFaqsCount());
+                    }}
+            );
         }
         notifyDataSetChanged();
     }

--- a/library/src/main/java/candybar/lib/adapters/HomeAdapter.java
+++ b/library/src/main/java/candybar/lib/adapters/HomeAdapter.java
@@ -57,6 +57,7 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.URL;
 import java.net.URLConnection;
+import java.util.HashMap;
 import java.util.List;
 
 import candybar.lib.R;
@@ -331,6 +332,16 @@ public class HomeAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
             iconRequestViewHolder.themedApps.setText(mContext.getResources().getString(
                     R.string.home_icon_request_themed_apps, themed));
 
+            CandyBarApplication.getConfiguration().getAnalyticsHandler().logEvent(
+                    "stats",
+                    new HashMap<String, Object>() {{
+                        put("section", "home");
+                        put("installed", installed);
+                        put("missed", missed);
+                        put("themed", themed);
+                    }}
+            );
+
             iconRequestViewHolder.progress.setMax(installed);
             iconRequestViewHolder.progress.setProgress(themed);
         } else if (holder.getItemViewType() == TYPE_WALLPAPERS) {
@@ -452,11 +463,27 @@ public class HomeAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
         public void onClick(View view) {
             int id = view.getId();
             if (id == R.id.rate) {
+                CandyBarApplication.getConfiguration().getAnalyticsHandler().logEvent(
+                        "click",
+                        new HashMap<String, Object>() {{
+                            put("section", "home");
+                            put("action", "open_dialog");
+                            put("item", "rate_and_review");
+                        }}
+                );
                 Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(mContext.getResources().getString(R.string.rate_and_review_link)
                         .replaceAll("\\{\\{packageName\\}\\}", mContext.getPackageName())));
                 intent.addFlags(Intent.FLAG_ACTIVITY_BROUGHT_TO_FRONT);
                 mContext.startActivity(intent);
             } else if (id == R.id.share) {
+                CandyBarApplication.getConfiguration().getAnalyticsHandler().logEvent(
+                        "click",
+                        new HashMap<String, Object>() {{
+                            put("section", "home");
+                            put("action", "open_dialog");
+                            put("item", "share");
+                        }}
+                );
                 Intent intent = new Intent(Intent.ACTION_SEND);
                 intent.setType("text/plain");
                 intent.putExtra(Intent.EXTRA_SUBJECT, mContext.getResources().getString(
@@ -469,6 +496,14 @@ public class HomeAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
                 mContext.startActivity(Intent.createChooser(intent,
                         mContext.getResources().getString(R.string.app_client)));
             } else if (id == R.id.update) {
+                CandyBarApplication.getConfiguration().getAnalyticsHandler().logEvent(
+                        "click",
+                        new HashMap<String, Object>() {{
+                            put("section", "home");
+                            put("action", "open_dialog");
+                            put("item", "update");
+                        }}
+                );
                 new UpdateChecker().execute();
             }
         }
@@ -663,11 +698,27 @@ public class HomeAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
 
                 switch (mHomes.get(position).getType()) {
                     case APPLY:
+                        CandyBarApplication.getConfiguration().getAnalyticsHandler().logEvent(
+                                "click",
+                                new HashMap<String, Object>() {{
+                                    put("section", "home");
+                                    put("action", "navigate");
+                                    put("item", "icon_apply");
+                                }}
+                        );
                         if (!quickApply || !LauncherHelper.quickApply(mContext)) {
                             ((CandyBarMainActivity) mContext).selectPosition(1);
                         }
                         break;
                     case DONATE:
+                        CandyBarApplication.getConfiguration().getAnalyticsHandler().logEvent(
+                                "click",
+                                new HashMap<String, Object>() {{
+                                    put("section", "home");
+                                    put("action", "open_dialog");
+                                    put("item", "donate");
+                                }}
+                        );
                         if (mContext instanceof CandyBarMainActivity) {
                             if (CandyBarApplication.getConfiguration().getDonationLinks() != null) {
                                 DonationLinksFragment.showDonationLinksDialog(((AppCompatActivity) mContext).getSupportFragmentManager());
@@ -679,6 +730,14 @@ public class HomeAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
                         }
                         break;
                     case ICONS:
+                        CandyBarApplication.getConfiguration().getAnalyticsHandler().logEvent(
+                                "click",
+                                new HashMap<String, Object>() {{
+                                    put("section", "home");
+                                    put("action", "navigate");
+                                    put("item", "icons");
+                                }}
+                        );
                         ((CandyBarMainActivity) mContext).selectPosition(2);
                         break;
                     case DIMENSION:
@@ -771,6 +830,14 @@ public class HomeAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
         public void onClick(View view) {
             int id = view.getId();
             if (id == R.id.container) {
+                CandyBarApplication.getConfiguration().getAnalyticsHandler().logEvent(
+                        "click",
+                        new HashMap<String, Object>() {{
+                            put("section", "home");
+                            put("action", "navigate");
+                            put("item", "icon_request");
+                        }}
+                );
                 ((CandyBarMainActivity) mContext).selectPosition(3);
             }
         }
@@ -888,6 +955,14 @@ public class HomeAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
         public void onClick(View view) {
             int id = view.getId();
             if (id == R.id.container) {
+                CandyBarApplication.getConfiguration().getAnalyticsHandler().logEvent(
+                        "click",
+                        new HashMap<String, Object>() {{
+                            put("section", "home");
+                            put("action", "open_dialog");
+                            put("item", "other_apps");
+                        }}
+                );
                 if (CandyBarApplication.getConfiguration().getOtherApps() != null) {
                     OtherAppsFragment.showOtherAppsDialog(((AppCompatActivity) mContext).getSupportFragmentManager());
                     return;

--- a/library/src/main/java/candybar/lib/adapters/IconsAdapter.java
+++ b/library/src/main/java/candybar/lib/adapters/IconsAdapter.java
@@ -29,12 +29,14 @@ import com.danimahardhika.android.helpers.core.SoftKeyboardHelper;
 import com.google.android.material.tabs.TabLayout;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
 
 import candybar.lib.R;
+import candybar.lib.applications.CandyBarApplication;
 import candybar.lib.databases.Database;
 import candybar.lib.fragments.IconsFragment;
 import candybar.lib.helpers.IconsHelper;
@@ -364,6 +366,29 @@ public class IconsAdapter extends RecyclerView.Adapter<IconsAdapter.ViewHolder> 
                     mIcons.add(icon);
                 }
             }
+        }
+        if (mIcons.size() == 0) {
+            CandyBarApplication.getConfiguration().getAnalyticsHandler().logEvent(
+                    "click",
+                    new HashMap<String, Object>() {{
+                        put("section", "icons");
+                        put("action", "search");
+                        put("item", query);
+                        put("found", "no");
+                        put("number_of_icons", mIcons.size());
+                    }}
+            );
+        } else {
+            CandyBarApplication.getConfiguration().getAnalyticsHandler().logEvent(
+                    "click",
+                    new HashMap<String, Object>() {{
+                        put("section", "icons");
+                        put("action", "search");
+                        put("item", query);
+                        put("found", "yes");
+                        put("number_of_icons", mIcons.size());
+                    }}
+            );
         }
         notifyDataSetChanged();
     }

--- a/library/src/main/java/candybar/lib/adapters/LauncherAdapter.java
+++ b/library/src/main/java/candybar/lib/adapters/LauncherAdapter.java
@@ -17,9 +17,11 @@ import com.bumptech.glide.Glide;
 import com.bumptech.glide.load.engine.DiskCacheStrategy;
 import com.bumptech.glide.load.resource.bitmap.BitmapTransitionOptions;
 
+import java.util.HashMap;
 import java.util.List;
 
 import candybar.lib.R;
+import candybar.lib.applications.CandyBarApplication;
 import candybar.lib.helpers.LauncherHelper;
 import candybar.lib.items.Icon;
 import candybar.lib.preferences.Preferences;

--- a/library/src/main/java/candybar/lib/adapters/RequestAdapter.java
+++ b/library/src/main/java/candybar/lib/adapters/RequestAdapter.java
@@ -29,6 +29,7 @@ import com.danimahardhika.android.helpers.core.utils.LogUtil;
 import com.google.android.material.card.MaterialCardView;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 
 import candybar.lib.R;

--- a/library/src/main/java/candybar/lib/adapters/SettingsAdapter.java
+++ b/library/src/main/java/candybar/lib/adapters/SettingsAdapter.java
@@ -24,10 +24,12 @@ import com.danimahardhika.android.helpers.core.utils.LogUtil;
 import java.io.File;
 import java.text.DecimalFormat;
 import java.text.NumberFormat;
+import java.util.HashMap;
 import java.util.List;
 
 import candybar.lib.R;
 import candybar.lib.activities.CandyBarMainActivity;
+import candybar.lib.applications.CandyBarApplication;
 import candybar.lib.databases.Database;
 import candybar.lib.fragments.SettingsFragment;
 import candybar.lib.fragments.dialog.ChangelogFragment;
@@ -174,12 +176,28 @@ public class SettingsAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolde
                 Setting setting = mSettings.get(position);
                 switch (setting.getType()) {
                     case CACHE:
+                        CandyBarApplication.getConfiguration().getAnalyticsHandler().logEvent(
+                                "click",
+                                new HashMap<String, Object>() {{
+                                    put("section", "settings");
+                                    put("action", "open_dialog");
+                                    put("item", "clear_cache");
+                                }}
+                        );
                         new MaterialDialog.Builder(mContext)
                                 .typeface(TypefaceHelper.getMedium(mContext), TypefaceHelper.getRegular(mContext))
                                 .content(R.string.pref_data_cache_clear_dialog)
                                 .positiveText(R.string.clear)
                                 .negativeText(android.R.string.cancel)
                                 .onPositive((dialog, which) -> {
+                                    CandyBarApplication.getConfiguration().getAnalyticsHandler().logEvent(
+                                            "click",
+                                            new HashMap<String, Object>() {{
+                                                put("section", "settings");
+                                                put("action", "confirm");
+                                                put("item", "clear_cache");
+                                            }}
+                                    );
                                     try {
                                         File cache = mContext.getCacheDir();
                                         FileHelper.clearDirectory(cache);
@@ -197,15 +215,41 @@ public class SettingsAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolde
                                         LogUtil.e(Log.getStackTraceString(e));
                                     }
                                 })
+                                .onNegative(((dialog, which) -> {
+                                    CandyBarApplication.getConfiguration().getAnalyticsHandler().logEvent(
+                                            "click",
+                                            new HashMap<String, Object>() {{
+                                                put("section", "settings");
+                                                put("action", "cancel");
+                                                put("item", "clear_cache");
+                                            }}
+                                    );
+                                }))
                                 .show();
                         break;
                     case ICON_REQUEST:
+                        CandyBarApplication.getConfiguration().getAnalyticsHandler().logEvent(
+                                "click",
+                                new HashMap<String, Object>() {{
+                                    put("section", "settings");
+                                    put("action", "open_dialog");
+                                    put("item", "clear_icon_request_data");
+                                }}
+                        );
                         new MaterialDialog.Builder(mContext)
                                 .typeface(TypefaceHelper.getMedium(mContext), TypefaceHelper.getRegular(mContext))
                                 .content(R.string.pref_data_request_clear_dialog)
                                 .positiveText(R.string.clear)
                                 .negativeText(android.R.string.cancel)
                                 .onPositive((dialog, which) -> {
+                                    CandyBarApplication.getConfiguration().getAnalyticsHandler().logEvent(
+                                            "click",
+                                            new HashMap<String, Object>() {{
+                                                put("section", "settings");
+                                                put("action", "confirm");
+                                                put("item", "clear_icon_request_data");
+                                            }}
+                                    );
                                     Database.get(mContext).deleteIconRequestData();
 
                                     CandyBarMainActivity.sMissedApps = null;
@@ -214,9 +258,27 @@ public class SettingsAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolde
                                     Toast.makeText(mContext, R.string.pref_data_request_cleared,
                                             Toast.LENGTH_LONG).show();
                                 })
+                                .onNegative(((dialog, which) -> {
+                                    CandyBarApplication.getConfiguration().getAnalyticsHandler().logEvent(
+                                            "click",
+                                            new HashMap<String, Object>() {{
+                                                put("section", "settings");
+                                                put("action", "cancel");
+                                                put("item", "clear_icon_request_data");
+                                            }}
+                                    );
+                                }))
                                 .show();
                         break;
                     case RESTORE:
+                        CandyBarApplication.getConfiguration().getAnalyticsHandler().logEvent(
+                                "click",
+                                new HashMap<String, Object>() {{
+                                    put("section", "settings");
+                                    put("item", "restore_purchase_data");
+                                    put("action", "confirm_without_dialog");
+                                }}
+                        );
                         try {
                             InAppBillingListener listener = (InAppBillingListener) mContext;
                             listener.onRestorePurchases();
@@ -224,6 +286,14 @@ public class SettingsAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolde
                         }
                         break;
                     case PREMIUM_REQUEST:
+                        CandyBarApplication.getConfiguration().getAnalyticsHandler().logEvent(
+                                "click",
+                                new HashMap<String, Object>() {{
+                                    put("section", "settings");
+                                    put("item", "rebuild_premium_request");
+                                    put("action", "confirm_without_dialog");
+                                }}
+                        );
                         FragmentManager fm = ((AppCompatActivity) mContext).getSupportFragmentManager();
                         if (fm == null) return;
 
@@ -235,18 +305,58 @@ public class SettingsAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolde
                         }
                         break;
                     case THEME:
+                        CandyBarApplication.getConfiguration().getAnalyticsHandler().logEvent(
+                                "click",
+                                new HashMap<String, Object>() {{
+                                    put("section", "settings");
+                                    put("item", "change_theme");
+                                    put("action", "open_dialog");
+                                }}
+                        );
                         ThemeChooserFragment.showThemeChooser(((AppCompatActivity) mContext).getSupportFragmentManager());
                         break;
                     case LANGUAGE:
+                        CandyBarApplication.getConfiguration().getAnalyticsHandler().logEvent(
+                                "click",
+                                new HashMap<String, Object>() {{
+                                    put("section", "settings");
+                                    put("item", "change_language");
+                                    put("action", "open_dialog");
+                                }}
+                        );
                         LanguagesFragment.showLanguageChooser(((AppCompatActivity) mContext).getSupportFragmentManager());
                         break;
                     case REPORT_BUGS:
+                        CandyBarApplication.getConfiguration().getAnalyticsHandler().logEvent(
+                                "click",
+                                new HashMap<String, Object>() {{
+                                    put("section", "settings");
+                                    put("item", "report_bugs");
+                                    put("action", "open_dialog");
+                                }}
+                        );
                         ReportBugsHelper.prepareReportBugs(mContext);
                         break;
                     case CHANGELOG:
+                        CandyBarApplication.getConfiguration().getAnalyticsHandler().logEvent(
+                                "click",
+                                new HashMap<String, Object>() {{
+                                    put("section", "settings");
+                                    put("item", "changelog");
+                                    put("action", "open_dialog");
+                                }}
+                        );
                         ChangelogFragment.showChangelog(((AppCompatActivity) mContext).getSupportFragmentManager());
                         break;
                     case RESET_TUTORIAL:
+                        CandyBarApplication.getConfiguration().getAnalyticsHandler().logEvent(
+                                "click",
+                                new HashMap<String, Object>() {{
+                                    put("section", "settings");
+                                    put("item", "reset_tutorial");
+                                    put("action", "confirm_without_dialog");
+                                }}
+                        );
                         Preferences.get(mContext).setTimeToShowHomeIntro(true);
                         Preferences.get(mContext).setTimeToShowIconsIntro(true);
                         Preferences.get(mContext).setTimeToShowRequestIntro(true);

--- a/library/src/main/java/candybar/lib/applications/CandyBarApplication.java
+++ b/library/src/main/java/candybar/lib/applications/CandyBarApplication.java
@@ -12,8 +12,10 @@ import com.danimahardhika.android.helpers.core.utils.LogUtil;
 import java.text.SimpleDateFormat;
 import java.util.Arrays;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 
 import candybar.lib.R;
 import candybar.lib.activities.CandyBarCrashReport;
@@ -124,9 +126,17 @@ public abstract class CandyBarApplication extends MultiDexApplication {
             String submit(List<Request> requests, boolean isPremium);
         }
 
+        public interface AnalyticsHandler {
+            void logEvent(String eventName, HashMap<String, Object> params);
+
+            void logException(Exception exception);
+        }
+
         private EmailBodyGenerator mEmailBodyGenerator;
 
         private IconRequestHandler iconRequestHandler;
+
+        private AnalyticsHandler analyticsHandler;
 
         private NavigationIcon mNavigationIcon = NavigationIcon.STYLE_1;
         private NavigationViewHeader mNavigationViewHeader = NavigationViewHeader.NORMAL;
@@ -168,6 +178,11 @@ public abstract class CandyBarApplication extends MultiDexApplication {
 
         public Configuration setIconRequestHandler(@NonNull IconRequestHandler iconRequestHandler) {
             this.iconRequestHandler = iconRequestHandler;
+            return this;
+        }
+
+        public Configuration setAnalyticsHandler(@NonNull AnalyticsHandler analyticsHandler) {
+            this.analyticsHandler = analyticsHandler;
             return this;
         }
 
@@ -317,6 +332,29 @@ public abstract class CandyBarApplication extends MultiDexApplication {
         }
 
         public IconRequestHandler getIconRequestHandler() { return iconRequestHandler; }
+
+        public AnalyticsHandler getAnalyticsHandler() {
+            if (analyticsHandler == null) {
+                analyticsHandler = new AnalyticsHandler() {
+                    @Override
+                    public void logEvent(String eventName, HashMap<String, Object> params) {
+                        StringBuilder sb = new StringBuilder();
+                        for (Map.Entry<String, Object> entry : params.entrySet()) {
+                            sb.append(" ");
+                            sb.append(entry.getKey());
+                            sb.append("=");
+                            sb.append(entry.getValue());
+                        }
+                        LogUtil.d("ANALYTICS EVENT: ".concat(eventName).concat(sb.toString()));
+                    }
+                    @Override
+                    public void logException(Exception exception) {
+                        LogUtil.e(exception.getStackTrace().toString());
+                    }
+                };
+            }
+            return analyticsHandler;
+        }
 
         public List<DonationLink> getDonationLinks() {
             return mDonationLinks;

--- a/library/src/main/java/candybar/lib/fragments/AboutFragment.java
+++ b/library/src/main/java/candybar/lib/fragments/AboutFragment.java
@@ -15,6 +15,8 @@ import androidx.recyclerview.widget.StaggeredGridLayoutManager;
 
 import com.danimahardhika.android.helpers.core.ViewHelper;
 
+import java.util.HashMap;
+
 import candybar.lib.R;
 import candybar.lib.adapters.AboutAdapter;
 import candybar.lib.applications.CandyBarApplication;
@@ -58,6 +60,10 @@ public class AboutFragment extends Fragment {
     @Override
     public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
+        CandyBarApplication.getConfiguration().getAnalyticsHandler().logEvent(
+                "view",
+                new HashMap<String, Object>() {{ put("section", "about"); }}
+        );
 
         resetRecyclerViewPadding(requireActivity().getResources().getConfiguration().orientation);
         mRecyclerView.setItemAnimator(new DefaultItemAnimator());

--- a/library/src/main/java/candybar/lib/fragments/ApplyFragment.java
+++ b/library/src/main/java/candybar/lib/fragments/ApplyFragment.java
@@ -21,6 +21,7 @@ import com.danimahardhika.android.helpers.core.utils.LogUtil;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 
 import candybar.lib.R;
@@ -70,6 +71,11 @@ public class ApplyFragment extends Fragment {
     @Override
     public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
+
+        CandyBarApplication.getConfiguration().getAnalyticsHandler().logEvent(
+                "view",
+                new HashMap<String, Object>() {{ put("section", "icon_apply"); }}
+        );
 
         mRecyclerView.setItemAnimator(new DefaultItemAnimator());
         mRecyclerView.setLayoutManager(new GridLayoutManager(getActivity(), 1));

--- a/library/src/main/java/candybar/lib/fragments/FAQsFragment.java
+++ b/library/src/main/java/candybar/lib/fragments/FAQsFragment.java
@@ -30,10 +30,12 @@ import com.danimahardhika.android.helpers.core.utils.LogUtil;
 import com.pluscubed.recyclerfastscroll.RecyclerFastScroller;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 
 import candybar.lib.R;
 import candybar.lib.adapters.FAQsAdapter;
+import candybar.lib.applications.CandyBarApplication;
 import candybar.lib.items.FAQs;
 import candybar.lib.preferences.Preferences;
 import candybar.lib.utils.AsyncTaskBase;
@@ -84,6 +86,11 @@ public class FAQsFragment extends Fragment {
     @Override
     public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
+
+        CandyBarApplication.getConfiguration().getAnalyticsHandler().logEvent(
+                "view",
+                new HashMap<String, Object>() {{ put("section", "faq"); }}
+        );
 
         mRecyclerView.setItemAnimator(new DefaultItemAnimator());
         mRecyclerView.setHasFixedSize(true);

--- a/library/src/main/java/candybar/lib/fragments/HomeFragment.java
+++ b/library/src/main/java/candybar/lib/fragments/HomeFragment.java
@@ -16,6 +16,7 @@ import androidx.recyclerview.widget.RecyclerView;
 import androidx.recyclerview.widget.StaggeredGridLayoutManager;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Objects;
 
@@ -69,6 +70,11 @@ public class HomeFragment extends Fragment implements HomeListener {
     @Override
     public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
+
+        CandyBarApplication.getConfiguration().getAnalyticsHandler().logEvent(
+                "view",
+                new HashMap<String, Object>() {{ put("section", "home"); }}
+        );
 
         mManager = new StaggeredGridLayoutManager(
                 requireActivity().getResources().getInteger(R.integer.home_column_count),

--- a/library/src/main/java/candybar/lib/fragments/IconsFragment.java
+++ b/library/src/main/java/candybar/lib/fragments/IconsFragment.java
@@ -20,11 +20,13 @@ import com.danimahardhika.android.helpers.core.ViewHelper;
 
 import java.lang.ref.WeakReference;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 
 import candybar.lib.R;
 import candybar.lib.activities.CandyBarMainActivity;
 import candybar.lib.adapters.IconsAdapter;
+import candybar.lib.applications.CandyBarApplication;
 import candybar.lib.databases.Database;
 import candybar.lib.items.Icon;
 import me.zhanghai.android.fastscroll.FastScrollerBuilder;
@@ -98,6 +100,11 @@ public class IconsFragment extends Fragment {
     @Override
     public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
+
+        CandyBarApplication.getConfiguration().getAnalyticsHandler().logEvent(
+                "view",
+                new HashMap<String, Object>() {{ put("section", "icons"); }}
+        );
 
         setupViewVisibility();
 

--- a/library/src/main/java/candybar/lib/fragments/IconsSearchFragment.java
+++ b/library/src/main/java/candybar/lib/fragments/IconsSearchFragment.java
@@ -34,6 +34,7 @@ import com.pluscubed.recyclerfastscroll.RecyclerFastScroller;
 import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 
 import candybar.lib.R;
@@ -92,6 +93,11 @@ public class IconsSearchFragment extends Fragment {
     @Override
     public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
+
+        CandyBarApplication.getConfiguration().getAnalyticsHandler().logEvent(
+                "view",
+                new HashMap<String, Object>() {{ put("section", "icons_search"); }}
+        );
 
         setHasOptionsMenu(true);
 

--- a/library/src/main/java/candybar/lib/fragments/PresetsFragment.java
+++ b/library/src/main/java/candybar/lib/fragments/PresetsFragment.java
@@ -34,11 +34,13 @@ import com.pluscubed.recyclerfastscroll.RecyclerFastScroller;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 
 import candybar.lib.R;
 import candybar.lib.adapters.PresetsAdapter;
+import candybar.lib.applications.CandyBarApplication;
 import candybar.lib.helpers.TypefaceHelper;
 import candybar.lib.items.Preset;
 import candybar.lib.preferences.Preferences;
@@ -89,6 +91,11 @@ public class PresetsFragment extends Fragment {
     @Override
     public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
+
+        CandyBarApplication.getConfiguration().getAnalyticsHandler().logEvent(
+                "view",
+                new HashMap<String, Object>() {{ put("section", "presets"); }}
+        );
 
         ViewCompat.setNestedScrollingEnabled(mRecyclerView, false);
 

--- a/library/src/main/java/candybar/lib/fragments/RequestFragment.java
+++ b/library/src/main/java/candybar/lib/fragments/RequestFragment.java
@@ -53,6 +53,7 @@ import java.io.InputStreamReader;
 import java.net.URL;
 import java.net.URLConnection;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -128,6 +129,11 @@ public class RequestFragment extends Fragment implements View.OnClickListener {
     @Override
     public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
+
+        CandyBarApplication.getConfiguration().getAnalyticsHandler().logEvent(
+                "view",
+                new HashMap<String, Object>() {{ put("section", "icon_request"); }}
+        );
 
         setHasOptionsMenu(false);
         resetRecyclerViewPadding(getResources().getConfiguration().orientation);

--- a/library/src/main/java/candybar/lib/fragments/SettingsFragment.java
+++ b/library/src/main/java/candybar/lib/fragments/SettingsFragment.java
@@ -27,6 +27,7 @@ import java.io.File;
 import java.text.DecimalFormat;
 import java.text.NumberFormat;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 
 import candybar.lib.R;
@@ -84,6 +85,11 @@ public class SettingsFragment extends Fragment {
     @Override
     public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
+
+        CandyBarApplication.getConfiguration().getAnalyticsHandler().logEvent(
+                "view",
+                new HashMap<String, Object>() {{ put("section", "settings"); }}
+        );
 
         mRecyclerView.setItemAnimator(new DefaultItemAnimator());
         mRecyclerView.setLayoutManager(new LinearLayoutManager(getActivity()));

--- a/library/src/main/java/candybar/lib/fragments/WallpapersFragment.java
+++ b/library/src/main/java/candybar/lib/fragments/WallpapersFragment.java
@@ -43,6 +43,7 @@ import com.pluscubed.recyclerfastscroll.RecyclerFastScroller;
 import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.util.HashMap;
 import java.util.List;
 
 import candybar.lib.R;
@@ -105,6 +106,11 @@ public class WallpapersFragment extends Fragment {
     @Override
     public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
+
+        CandyBarApplication.getConfiguration().getAnalyticsHandler().logEvent(
+                "view",
+                new HashMap<String, Object>() {{ put("section", "wallpapers"); }}
+        );
 
         ViewCompat.setNestedScrollingEnabled(mRecyclerView, false);
 

--- a/library/src/main/java/candybar/lib/fragments/dialog/LanguagesFragment.java
+++ b/library/src/main/java/candybar/lib/fragments/dialog/LanguagesFragment.java
@@ -15,11 +15,13 @@ import androidx.fragment.app.FragmentTransaction;
 import com.afollestad.materialdialogs.MaterialDialog;
 import com.danimahardhika.android.helpers.core.utils.LogUtil;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 
 import candybar.lib.R;
 import candybar.lib.adapters.dialog.LanguagesAdapter;
+import candybar.lib.applications.CandyBarApplication;
 import candybar.lib.helpers.LocaleHelper;
 import candybar.lib.helpers.TypefaceHelper;
 import candybar.lib.items.Language;
@@ -78,6 +80,16 @@ public class LanguagesFragment extends DialogFragment {
                 .typeface(TypefaceHelper.getMedium(requireActivity()), TypefaceHelper.getRegular(requireActivity()))
                 .title(R.string.pref_language_header)
                 .negativeText(R.string.close)
+                .onNegative(((_dialog, which) -> {
+                    CandyBarApplication.getConfiguration().getAnalyticsHandler().logEvent(
+                            "click",
+                            new HashMap<String, Object>() {{
+                                put("section", "settings");
+                                put("action", "cancel");
+                                put("item", "change_language");
+                            }}
+                    );
+                }))
                 .build();
         dialog.show();
 
@@ -106,6 +118,15 @@ public class LanguagesFragment extends DialogFragment {
     }
 
     public void setLanguage(@NonNull Locale locale) {
+        CandyBarApplication.getConfiguration().getAnalyticsHandler().logEvent(
+                "click",
+                new HashMap<String, Object>() {{
+                    put("section", "settings");
+                    put("action", "confirm");
+                    put("item", "change_language");
+                    put("locale", locale.getDisplayName());
+                }}
+        );
         mLocale = locale;
         dismiss();
     }

--- a/library/src/main/java/candybar/lib/helpers/IconsHelper.java
+++ b/library/src/main/java/candybar/lib/helpers/IconsHelper.java
@@ -31,6 +31,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 
 import candybar.lib.R;
@@ -170,6 +171,14 @@ public class IconsHelper {
     }
 
     public static void selectIcon(@NonNull Context context, int action, Icon icon) {
+        CandyBarApplication.getConfiguration().getAnalyticsHandler().logEvent(
+                "click",
+                new HashMap<String, Object>() {{
+                    put("section", "icons");
+                    put("action", "pick_icon");
+                    put("item", icon.getDrawableName());
+                }}
+        );
         if (action == IntentHelper.ICON_PICKER && CandyBarGlideModule.isValidContextForGlide(context)) {
             Glide.with(context)
                     .asBitmap()

--- a/library/src/main/java/candybar/lib/helpers/LauncherHelper.java
+++ b/library/src/main/java/candybar/lib/helpers/LauncherHelper.java
@@ -14,7 +14,10 @@ import androidx.appcompat.app.AppCompatActivity;
 
 import com.afollestad.materialdialogs.MaterialDialog;
 
+import java.util.HashMap;
+
 import candybar.lib.R;
+import candybar.lib.applications.CandyBarApplication;
 
 /*
  * CandyBar - Material Dashboard
@@ -146,6 +149,14 @@ public class LauncherHelper {
     }
 
     public static void apply(@NonNull Context context, String packageName, String launcherName) {
+        CandyBarApplication.getConfiguration().getAnalyticsHandler().logEvent(
+                "click",
+                new HashMap<String, Object>() {{
+                    put("section", "apply");
+                    put("action", "open_dialog");
+                    put("launcher", packageName);
+                }}
+        );
         applyLauncher(context, packageName, launcherName, getLauncher(packageName));
     }
 
@@ -167,6 +178,14 @@ public class LauncherHelper {
                     context.sendBroadcast(abc1);
                     context.startActivity(abc);
                     ((AppCompatActivity) context).finish();
+                    CandyBarApplication.getConfiguration().getAnalyticsHandler().logEvent(
+                            "click",
+                            new HashMap<String, Object>() {{
+                                put("section", "apply");
+                                put("action", "confirm");
+                                put("launcher", launcherPackage);
+                            }}
+                    );
                 } catch (ActivityNotFoundException | NullPointerException e) {
                     openGooglePlay(context, launcherPackage, launcherName);
                 }
@@ -179,6 +198,14 @@ public class LauncherHelper {
                     action.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
                     context.startActivity(action);
                     ((AppCompatActivity) context).finish();
+                    CandyBarApplication.getConfiguration().getAnalyticsHandler().logEvent(
+                            "click",
+                            new HashMap<String, Object>() {{
+                                put("section", "apply");
+                                put("action", "confirm");
+                                put("launcher", launcherPackage);
+                            }}
+                    );
                 } catch (ActivityNotFoundException | NullPointerException e) {
                     openGooglePlay(context, launcherPackage, launcherName);
                 }
@@ -190,6 +217,14 @@ public class LauncherHelper {
                     adw.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
                     context.startActivity(adw);
                     ((AppCompatActivity) context).finish();
+                    CandyBarApplication.getConfiguration().getAnalyticsHandler().logEvent(
+                            "click",
+                            new HashMap<String, Object>() {{
+                                put("section", "apply");
+                                put("action", "confirm");
+                                put("launcher", launcherPackage);
+                            }}
+                    );
                 } catch (ActivityNotFoundException | NullPointerException e) {
                     openGooglePlay(context, launcherPackage, launcherName);
                 }
@@ -201,6 +236,14 @@ public class LauncherHelper {
                     apex.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
                     context.startActivity(apex);
                     ((AppCompatActivity) context).finish();
+                    CandyBarApplication.getConfiguration().getAnalyticsHandler().logEvent(
+                            "click",
+                            new HashMap<String, Object>() {{
+                                put("section", "apply");
+                                put("action", "confirm");
+                                put("launcher", launcherPackage);
+                            }}
+                    );
                 } catch (ActivityNotFoundException | NullPointerException e) {
                     openGooglePlay(context, launcherPackage, launcherName);
                 }
@@ -212,6 +255,14 @@ public class LauncherHelper {
                     atom.putExtra("packageName", context.getPackageName());
                     context.startActivity(atom);
                     ((AppCompatActivity) context).finish();
+                    CandyBarApplication.getConfiguration().getAnalyticsHandler().logEvent(
+                            "click",
+                            new HashMap<String, Object>() {{
+                                put("section", "apply");
+                                put("action", "confirm");
+                                put("launcher", launcherPackage);
+                            }}
+                    );
                 } catch (ActivityNotFoundException | NullPointerException e) {
                     openGooglePlay(context, launcherPackage, launcherName);
                 }
@@ -223,6 +274,14 @@ public class LauncherHelper {
                     aviate.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
                     context.startActivity(aviate);
                     ((AppCompatActivity) context).finish();
+                    CandyBarApplication.getConfiguration().getAnalyticsHandler().logEvent(
+                            "click",
+                            new HashMap<String, Object>() {{
+                                put("section", "apply");
+                                put("action", "confirm");
+                                put("launcher", launcherPackage);
+                            }}
+                    );
                 } catch (ActivityNotFoundException | NullPointerException e) {
                     openGooglePlay(context, launcherPackage, launcherName);
                 }
@@ -237,6 +296,14 @@ public class LauncherHelper {
                             "org.cyanogenmod.theme.chooser.ChooserActivity"));
                     cmtheme.putExtra("pkgName", context.getPackageName());
                     context.startActivity(cmtheme);
+                    CandyBarApplication.getConfiguration().getAnalyticsHandler().logEvent(
+                            "click",
+                            new HashMap<String, Object>() {{
+                                put("section", "apply");
+                                put("action", "confirm");
+                                put("launcher", launcherPackage);
+                            }}
+                    );
                 } catch (ActivityNotFoundException | NullPointerException e) {
                     Toast.makeText(context, R.string.apply_cmtheme_not_available,
                             Toast.LENGTH_LONG).show();
@@ -258,6 +325,14 @@ public class LauncherHelper {
                     context.sendBroadcast(flickAction);
                     context.startActivity(flick);
                     ((AppCompatActivity) context).finish();
+                    CandyBarApplication.getConfiguration().getAnalyticsHandler().logEvent(
+                            "click",
+                            new HashMap<String, Object>() {{
+                                put("section", "apply");
+                                put("action", "confirm");
+                                put("launcher", launcherPackage);
+                            }}
+                    );
                 } catch (ActivityNotFoundException | NullPointerException e) {
                     openGooglePlay(context, launcherPackage, launcherName);
                 }
@@ -273,6 +348,14 @@ public class LauncherHelper {
                     context.sendBroadcast(go);
                     context.startActivity(goex);
                     ((AppCompatActivity) context).finish();
+                    CandyBarApplication.getConfiguration().getAnalyticsHandler().logEvent(
+                            "click",
+                            new HashMap<String, Object>() {{
+                                put("section", "apply");
+                                put("action", "confirm");
+                                put("launcher", launcherPackage);
+                            }}
+                    );
                 } catch (ActivityNotFoundException | NullPointerException e) {
                     openGooglePlay(context, launcherPackage, launcherName);
                 }
@@ -292,6 +375,14 @@ public class LauncherHelper {
                     kiss.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
                     context.startActivity(kiss);
                     ((AppCompatActivity) context).finish();
+                    CandyBarApplication.getConfiguration().getAnalyticsHandler().logEvent(
+                            "click",
+                            new HashMap<String, Object>() {{
+                                put("section", "apply");
+                                put("action", "confirm");
+                                put("launcher", launcherPackage);
+                            }}
+                    );
                 } catch (ActivityNotFoundException | NullPointerException e) {
                     openGooglePlay(context, launcherPackage, launcherName);
                 }
@@ -302,6 +393,14 @@ public class LauncherHelper {
                     lawnchair.putExtra("packageName", context.getPackageName());
                     context.startActivity(lawnchair);
                     ((AppCompatActivity) context).finish();
+                    CandyBarApplication.getConfiguration().getAnalyticsHandler().logEvent(
+                            "click",
+                            new HashMap<String, Object>() {{
+                                put("section", "apply");
+                                put("action", "confirm");
+                                put("launcher", launcherPackage);
+                            }}
+                    );
                 } catch (ActivityNotFoundException | NullPointerException e) {
                     openGooglePlay(context, launcherPackage, launcherName);
                 }
@@ -320,6 +419,14 @@ public class LauncherHelper {
                     lucid.putExtra("icontheme", context.getPackageName());
                     context.startActivity(lucid);
                     ((AppCompatActivity) context).finish();
+                    CandyBarApplication.getConfiguration().getAnalyticsHandler().logEvent(
+                            "click",
+                            new HashMap<String, Object>() {{
+                                put("section", "apply");
+                                put("action", "confirm");
+                                put("launcher", launcherPackage);
+                            }}
+                    );
                 } catch (ActivityNotFoundException | NullPointerException e) {
                     openGooglePlay(context, launcherPackage, launcherName);
                 }
@@ -336,6 +443,14 @@ public class LauncherHelper {
                     final Intent niagara = new Intent("bitpit.launcher.APPLY_ICONS");
                     niagara.putExtra("packageName", context.getPackageName());
                     context.startActivity(niagara);
+                    CandyBarApplication.getConfiguration().getAnalyticsHandler().logEvent(
+                            "click",
+                            new HashMap<String, Object>() {{
+                                put("section", "apply");
+                                put("action", "confirm");
+                                put("launcher", launcherPackage);
+                            }}
+                    );
                 } catch (ActivityNotFoundException | NullPointerException e) {
                     openGooglePlay(context, launcherPackage, launcherName);
                 }
@@ -353,6 +468,14 @@ public class LauncherHelper {
                     context.sendBroadcast(next2);
                     context.startActivity(next);
                     ((AppCompatActivity) context).finish();
+                    CandyBarApplication.getConfiguration().getAnalyticsHandler().logEvent(
+                            "click",
+                            new HashMap<String, Object>() {{
+                                put("section", "apply");
+                                put("action", "confirm");
+                                put("launcher", launcherPackage);
+                            }}
+                    );
                 } catch (ActivityNotFoundException | NullPointerException e) {
                     openGooglePlay(context, launcherPackage, launcherName);
                 }
@@ -366,6 +489,14 @@ public class LauncherHelper {
                     nova.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
                     context.startActivity(nova);
                     ((AppCompatActivity) context).finish();
+                    CandyBarApplication.getConfiguration().getAnalyticsHandler().logEvent(
+                            "click",
+                            new HashMap<String, Object>() {{
+                                put("section", "apply");
+                                put("action", "confirm");
+                                put("launcher", launcherPackage);
+                            }}
+                    );
                 } catch (ActivityNotFoundException | NullPointerException e) {
                     openGooglePlay(context, launcherPackage, launcherName);
                 }
@@ -384,6 +515,14 @@ public class LauncherHelper {
                     posidon.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
                     context.startActivity(posidon);
                     ((AppCompatActivity) context).finish();
+                    CandyBarApplication.getConfiguration().getAnalyticsHandler().logEvent(
+                            "click",
+                            new HashMap<String, Object>() {{
+                                put("section", "apply");
+                                put("action", "confirm");
+                                put("launcher", launcherPackage);
+                            }}
+                    );
                 } catch (ActivityNotFoundException | NullPointerException e) {
                     openGooglePlay(context, launcherPackage, launcherName);
                 }
@@ -395,6 +534,14 @@ public class LauncherHelper {
                     smart.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
                     context.startActivity(smart);
                     ((AppCompatActivity) context).finish();
+                    CandyBarApplication.getConfiguration().getAnalyticsHandler().logEvent(
+                            "click",
+                            new HashMap<String, Object>() {{
+                                put("section", "apply");
+                                put("action", "confirm");
+                                put("launcher", launcherPackage);
+                            }}
+                    );
                 } catch (ActivityNotFoundException | NullPointerException e) {
                     openGooglePlay(context, launcherPackage, launcherName);
                 }
@@ -411,6 +558,14 @@ public class LauncherHelper {
                     context.sendBroadcast(soloAction);
                     context.startActivity(solo);
                     ((AppCompatActivity) context).finish();
+                    CandyBarApplication.getConfiguration().getAnalyticsHandler().logEvent(
+                            "click",
+                            new HashMap<String, Object>() {{
+                                put("section", "apply");
+                                put("action", "confirm");
+                                put("launcher", launcherPackage);
+                            }}
+                    );
                 } catch (ActivityNotFoundException | NullPointerException e) {
                     openGooglePlay(context, launcherPackage, launcherName);
                 }
@@ -421,6 +576,14 @@ public class LauncherHelper {
                     square.setComponent(ComponentName.unflattenFromString("com.ss.squarehome2/.ApplyThemeActivity"));
                     square.putExtra("com.ss.squarehome2.EXTRA_ICONPACK", context.getPackageName());
                     context.startActivity(square);
+                    CandyBarApplication.getConfiguration().getAnalyticsHandler().logEvent(
+                            "click",
+                            new HashMap<String, Object>() {{
+                                put("section", "apply");
+                                put("action", "confirm");
+                                put("launcher", launcherPackage);
+                            }}
+                    );
                 } catch (ActivityNotFoundException | NullPointerException e) {
                     openGooglePlay(context, launcherPackage, launcherName);
                 }
@@ -432,6 +595,14 @@ public class LauncherHelper {
                     neo.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
                     context.startActivity(neo);
                     ((AppCompatActivity) context).finish();
+                    CandyBarApplication.getConfiguration().getAnalyticsHandler().logEvent(
+                            "click",
+                            new HashMap<String, Object>() {{
+                                put("section", "apply");
+                                put("action", "confirm");
+                                put("launcher", launcherPackage);
+                            }}
+                    );
                 } catch (ActivityNotFoundException | NullPointerException e) {
                     openGooglePlay(context, launcherPackage, launcherName);
                 }
@@ -450,6 +621,14 @@ public class LauncherHelper {
                     nougat.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
                     context.startActivity(nougat);
                     ((AppCompatActivity) context).finish();
+                    CandyBarApplication.getConfiguration().getAnalyticsHandler().logEvent(
+                            "click",
+                            new HashMap<String, Object>() {{
+                                put("section", "apply");
+                                put("action", "confirm");
+                                put("launcher", launcherPackage);
+                            }}
+                    );
                 } catch (ActivityNotFoundException | NullPointerException e) {
                     openGooglePlay(context, launcherPackage, launcherName);
                 }
@@ -468,6 +647,14 @@ public class LauncherHelper {
                     m.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
                     context.startActivity(m);
                     ((AppCompatActivity) context).finish();
+                    CandyBarApplication.getConfiguration().getAnalyticsHandler().logEvent(
+                            "click",
+                            new HashMap<String, Object>() {{
+                                put("section", "apply");
+                                put("action", "confirm");
+                                put("launcher", launcherPackage);
+                            }}
+                    );
                 } catch (ActivityNotFoundException | NullPointerException e) {
                     openGooglePlay(context, launcherPackage, launcherName);
                 }
@@ -481,6 +668,14 @@ public class LauncherHelper {
                     asus.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
                     context.startActivity(asus);
                     ((AppCompatActivity) context).finish();
+                    CandyBarApplication.getConfiguration().getAnalyticsHandler().logEvent(
+                            "click",
+                            new HashMap<String, Object>() {{
+                                put("section", "apply");
+                                put("action", "confirm");
+                                put("launcher", launcherPackage);
+                            }}
+                    );
                 } catch (ActivityNotFoundException | NullPointerException e) {
                     openGooglePlay(context, launcherPackage, launcherName);
                 }
@@ -502,6 +697,14 @@ public class LauncherHelper {
                     context.sendBroadcast(zero1);
                     context.startActivity(zero);
                     ((AppCompatActivity) context).finish();
+                    CandyBarApplication.getConfiguration().getAnalyticsHandler().logEvent(
+                            "click",
+                            new HashMap<String, Object>() {{
+                                put("section", "apply");
+                                put("action", "confirm");
+                                put("launcher", launcherPackage);
+                            }}
+                    );
                 } catch (ActivityNotFoundException | NullPointerException e) {
                     openGooglePlay(context, launcherPackage, launcherName);
                 }
@@ -523,6 +726,14 @@ public class LauncherHelper {
                     context.sendBroadcast(v1);
                     context.startActivity(v);
                     ((AppCompatActivity) context).finish();
+                    CandyBarApplication.getConfiguration().getAnalyticsHandler().logEvent(
+                            "click",
+                            new HashMap<String, Object>() {{
+                                put("section", "apply");
+                                put("action", "confirm");
+                                put("launcher", launcherPackage);
+                            }}
+                    );
                 } catch (ActivityNotFoundException | NullPointerException e) {
                     openGooglePlay(context, launcherPackage, launcherName);
                 }
@@ -541,6 +752,14 @@ public class LauncherHelper {
                             context.getResources().getString(R.string.app_name)))
                     .positiveText(android.R.string.ok)
                     .onPositive((dialog, which) -> {
+                        CandyBarApplication.getConfiguration().getAnalyticsHandler().logEvent(
+                                "click",
+                                new HashMap<String, Object>() {{
+                                    put("section", "apply");
+                                    put("action", "manual_open_confirm");
+                                    put("launcher", launcherPackage);
+                                }}
+                        );
                         if (activity == null) return;
                         try {
                             final Intent intent = new Intent(Intent.ACTION_MAIN);
@@ -558,6 +777,16 @@ public class LauncherHelper {
                         }
                     })
                     .negativeText(android.R.string.cancel)
+                    .onNegative(((dialog, which) -> {
+                        CandyBarApplication.getConfiguration().getAnalyticsHandler().logEvent(
+                                "click",
+                                new HashMap<String, Object>() {{
+                                    put("section", "apply");
+                                    put("action", "manual_open_cancel");
+                                    put("launcher", launcherPackage);
+                                }}
+                        );
+                    }))
                     .show();
         } else {
             openGooglePlay(context, launcherPackage, launcherName);
@@ -592,11 +821,29 @@ public class LauncherHelper {
                         intent.setFlags(Intent.FLAG_ACTIVITY_NO_HISTORY);
                         context.startActivity(intent);
                         ((AppCompatActivity) context).finish();
+                        CandyBarApplication.getConfiguration().getAnalyticsHandler().logEvent(
+                                "click",
+                                new HashMap<String, Object>() {{
+                                    put("section", "apply");
+                                    put("action", "manual_open_confirm");
+                                    put("launcher", launcherPackage);
+                                }}
+                        );
                     } catch (ActivityNotFoundException | NullPointerException e) {
                         openGooglePlay(context, launcherPackage, launcherName);
                     }
                 })
                 .negativeText(android.R.string.cancel)
+                .onNegative(((dialog, which) -> {
+                    CandyBarApplication.getConfiguration().getAnalyticsHandler().logEvent(
+                            "click",
+                            new HashMap<String, Object>() {{
+                                put("section", "apply");
+                                put("action", "manual_open_cancel");
+                                put("launcher", launcherPackage);
+                            }}
+                    );
+                }))
                 .show();
     }
 
@@ -607,6 +854,14 @@ public class LauncherHelper {
                 .content(R.string.apply_launcher_incompatible, launcherName, launcherName)
                 .positiveText(android.R.string.yes)
                 .onPositive((dialog, which) -> {
+                    CandyBarApplication.getConfiguration().getAnalyticsHandler().logEvent(
+                            "click",
+                            new HashMap<String, Object>() {{
+                                put("section", "apply");
+                                put("action", "incompatible_third_party_open");
+                                put("launcher", launcherName);
+                            }}
+                    );
                     try {
                         Intent store = new Intent(Intent.ACTION_VIEW, Uri.parse(thirdPartyHelperURL));
                         context.startActivity(store);
@@ -616,6 +871,16 @@ public class LauncherHelper {
                     }
                 })
                 .negativeText(android.R.string.cancel)
+                .onNegative(((dialog, which) -> {
+                    CandyBarApplication.getConfiguration().getAnalyticsHandler().logEvent(
+                            "click",
+                            new HashMap<String, Object>() {{
+                                put("section", "apply");
+                                put("action", "incompatible_third_party_cancel");
+                                put("launcher", launcherName);
+                            }}
+                    );
+                }))
                 .show();
     }
 
@@ -635,6 +900,14 @@ public class LauncherHelper {
                 .content(R.string.apply_launcher_not_installed, launcherName)
                 .positiveText(context.getResources().getString(R.string.install))
                 .onPositive((dialog, which) -> {
+                    CandyBarApplication.getConfiguration().getAnalyticsHandler().logEvent(
+                            "click",
+                            new HashMap<String, Object>() {{
+                                put("section", "apply");
+                                put("action", "not_installed_google_play_open");
+                                put("launcher", packageName);
+                            }}
+                    );
                     try {
                         Intent store = new Intent(Intent.ACTION_VIEW, Uri.parse(
                                 "https://play.google.com/store/apps/details?id=" + packageName));
@@ -645,6 +918,16 @@ public class LauncherHelper {
                     }
                 })
                 .negativeText(android.R.string.cancel)
+                .onNegative(((dialog, which) -> {
+                    CandyBarApplication.getConfiguration().getAnalyticsHandler().logEvent(
+                            "click",
+                            new HashMap<String, Object>() {{
+                                put("section", "apply");
+                                put("action", "not_installed_google_play_cancel");
+                                put("launcher", packageName);
+                            }}
+                    );
+                }))
                 .show();
     }
 

--- a/library/src/main/java/candybar/lib/helpers/LocaleHelper.java
+++ b/library/src/main/java/candybar/lib/helpers/LocaleHelper.java
@@ -16,10 +16,12 @@ import androidx.annotation.Nullable;
 import com.danimahardhika.android.helpers.core.utils.LogUtil;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 
 import candybar.lib.R;
+import candybar.lib.applications.CandyBarApplication;
 import candybar.lib.items.Language;
 import candybar.lib.preferences.Preferences;
 
@@ -46,7 +48,6 @@ public class LocaleHelper {
     public static void setLocale(@NonNull Context context) {
         Locale locale = Preferences.get(context).getCurrentLocale();
         Locale.setDefault(locale);
-
         Configuration configuration = context.getResources().getConfiguration();
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
             LocaleList.setDefault(new LocaleList(locale));

--- a/library/src/main/java/candybar/lib/helpers/RequestHelper.java
+++ b/library/src/main/java/candybar/lib/helpers/RequestHelper.java
@@ -208,6 +208,15 @@ public class RequestHelper {
     }
 
     public static String sendPacificRequest(List<Request> requests, List<String> iconFiles, File directory, String apiKey) {
+        CandyBarApplication.getConfiguration().getAnalyticsHandler().logEvent(
+                "click",
+                new HashMap<String, Object>() {{
+                    put("section", "icon_request");
+                    put("action", "submit");
+                    put("item", "pacific");
+                    put("number_of_icons", requests.size());
+                }}
+        );
         okhttp3.RequestBody okRequestBody = new okhttp3.MultipartBody.Builder()
                 .setType(okhttp3.MultipartBody.FORM)
                 .addFormDataPart("apps", buildJsonForPacific(requests))
@@ -259,6 +268,16 @@ public class RequestHelper {
     }
 
     public static String sendCustomRequest(List<Request> requests, boolean isPremium) {
+        CandyBarApplication.getConfiguration().getAnalyticsHandler().logEvent(
+                "click",
+                new HashMap<String, Object>() {{
+                    put("section", "icon_request");
+                    put("action", "submit");
+                    put("item", "custom");
+                    put("type", isPremium ? "premium" : "regular");
+                    put("number_of_icons", requests.size());
+                }}
+        );
         String errorMessage;
         CandyBarApplication.Configuration.IconRequestHandler iconRequestHandler = CandyBarApplication.getConfiguration().getIconRequestHandler();
         if (iconRequestHandler != null) {

--- a/library/src/main/java/candybar/lib/preferences/Preferences.java
+++ b/library/src/main/java/candybar/lib/preferences/Preferences.java
@@ -9,6 +9,7 @@ import android.net.NetworkInfo;
 import androidx.annotation.NonNull;
 
 import java.lang.ref.WeakReference;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 
@@ -158,6 +159,14 @@ public class Preferences {
     }
 
     public void setTheme(Theme theme) {
+        CandyBarApplication.getConfiguration().getAnalyticsHandler().logEvent(
+                "click",
+                new HashMap<String, Object>() {{
+                    put("section", "settings");
+                    put("action", "change_theme");
+                    put("theme", theme.name());
+                }}
+        );
         getSharedPreferences().edit().putInt(KEY_THEME, theme.ordinal()).apply();
     }
 

--- a/library/src/main/java/candybar/lib/utils/InAppBillingClient.java
+++ b/library/src/main/java/candybar/lib/utils/InAppBillingClient.java
@@ -14,8 +14,10 @@ import com.android.billingclient.api.QueryPurchasesParams;
 import com.danimahardhika.android.helpers.core.utils.LogUtil;
 
 import java.lang.ref.WeakReference;
+import java.util.HashMap;
 import java.util.List;
 
+import candybar.lib.applications.CandyBarApplication;
 import candybar.lib.items.InAppBilling;
 import candybar.lib.preferences.Preferences;
 import candybar.lib.utils.listeners.InAppBillingListener;
@@ -95,6 +97,16 @@ public class InAppBillingClient implements PurchasesUpdatedListener, BillingClie
                 try {
                     ((InAppBillingListener) mInAppBilling.get().mContext)
                             .onProcessPurchase(purchases.get(0));
+                    for (Purchase purchase : purchases) {
+                        CandyBarApplication.getConfiguration().getAnalyticsHandler().logEvent(
+                                "purchase",
+                                new HashMap<String, Object>() {{
+                                    put("order_id", purchase.getOrderId());
+                                    put("order_timestamp", purchase.getPurchaseTime());
+                                    put("order_status", purchase.getPurchaseState());
+                                }}
+                        );
+                    }
                 } catch (Exception ignored) {
                 }
             }

--- a/library/src/main/java/candybar/lib/utils/InAppBillingClient.java
+++ b/library/src/main/java/candybar/lib/utils/InAppBillingClient.java
@@ -104,6 +104,8 @@ public class InAppBillingClient implements PurchasesUpdatedListener, BillingClie
                                     put("order_id", purchase.getOrderId());
                                     put("order_timestamp", purchase.getPurchaseTime());
                                     put("order_status", purchase.getPurchaseState());
+                                    put("products", String.join(",", purchase.getProducts()));
+                                    put("token", purchase.getPurchaseToken());
                                 }}
                         );
                     }


### PR DESCRIPTION
This PR adds a custom events handler that can be used to submit events to services such as FirebaseAnalytics or other key-value stores and in turn enable aggregated analysis of how users interact with the icon pack.

What's supported:
 * Screen views
 * Clicks (navigation/cards)
 * Wallpapers (view/click/apply)
 * Icons (bookmark/search)
 * Stats (installed/missed)

It allows for answering (among others) the following queries (in an anonymous and aggregated fashion):
 * Which launchers do my users use the most?
 * Which wallpapers are the most popular?
 * What's the coverage of themed icons?

None of the implemented analytics are invasive (i.e. icon coverage is reported in sums and not looking at any individual apps). I've been using this for almost a year in my fork and it has helped me tremendously to create more relevant content (wallpapers), to spot issues (e.g. icon searches yielding 0 results because of poorly named icons) and to create tutorial videos for the most popular launchers.

As a default, events would be printed to the console as DEBUG logs.