### PR TITLE
Allow overriding TapIntro colours

### DIFF
--- a/app/src/main/res/values/dashboard_configurations.xml
+++ b/app/src/main/res/values/dashboard_configurations.xml
@@ -97,5 +97,6 @@
     <!-- CONFIG: MISC -->
     <string name="config_json">https://zixpo.github.io/candybar-sources/candybar_config_alt.json</string>
     <bool name="show_intro">false</bool>
+    <bool name="use_legacy_intro_colors">true</bool>
 
 </resources>

--- a/library/src/main/java/candybar/lib/helpers/TapIntroHelper.java
+++ b/library/src/main/java/candybar/lib/helpers/TapIntroHelper.java
@@ -118,7 +118,7 @@ public class TapIntroHelper {
                                     RecyclerView.ViewHolder holder = recyclerView.findViewHolderForAdapterPosition(position);
                                     if (holder != null) {
                                         View view = holder.itemView;
-                                        float circleScale = 1.0f / context.getResources().getInteger(R.integer.tap_intro_circle_scale_percent);
+                                        float circleScale = 100.0f / context.getResources().getInteger(R.integer.tap_intro_circle_scale_percent);
                                         float targetRadius = (toDp(context, view.getMeasuredWidth()) - 20f) * circleScale;
 
                                         String desc = context.getResources().getString(R.string.tap_intro_home_apply_desc,
@@ -374,7 +374,7 @@ public class TapIntroHelper {
                                         if (holder != null) {
                                             View view = holder.itemView.findViewById(R.id.buy);
                                             if (view != null) {
-                                                float circleScale = 1.0f / context.getResources().getInteger(R.integer.tap_intro_circle_scale_percent);
+                                                float circleScale = 100.0f / context.getResources().getInteger(R.integer.tap_intro_circle_scale_percent);
                                                 float targetRadius = (toDp(context, view.getMeasuredWidth()) - 10f) * circleScale;
 
                                                 TapTarget tapTarget = TapTarget.forView(view,
@@ -472,7 +472,7 @@ public class TapIntroHelper {
 
                         View view = holder.itemView.findViewById(R.id.image);
                         if (view != null) {
-                            float circleScale = 1.0f / context.getResources().getInteger(R.integer.tap_intro_circle_scale_percent);
+                            float circleScale = 100.0f / context.getResources().getInteger(R.integer.tap_intro_circle_scale_percent);
                             float targetRadius = (toDp(context, view.getMeasuredWidth()) - 10f) * circleScale;
 
                             Typeface title = TypefaceHelper.getMedium(context);

--- a/library/src/main/java/candybar/lib/helpers/TapIntroHelper.java
+++ b/library/src/main/java/candybar/lib/helpers/TapIntroHelper.java
@@ -27,6 +27,9 @@ import com.getkeepsafe.taptargetview.TapTarget;
 import com.getkeepsafe.taptargetview.TapTargetSequence;
 import com.getkeepsafe.taptargetview.TapTargetView;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import candybar.lib.R;
 import candybar.lib.adapters.HomeAdapter;
 import candybar.lib.preferences.Preferences;
@@ -61,8 +64,19 @@ public class TapIntroHelper {
 
             new Handler().postDelayed(() -> {
                 try {
-                    int primary = ContextCompat.getColor(context, R.color.toolbarIcon);
-                    int secondary = ColorHelper.setColorAlpha(primary, 0.7f);
+                    int titleColor = ContextCompat.getColor(context, R.color.tapIntroTitle);
+                    int descriptionColor = ContextCompat.getColor(context, R.color.tapIntroDescription);
+                    int circleColorInner = ContextCompat.getColor(context, R.color.tapIntroCircleInner);
+                    int circleColorOuter = ContextCompat.getColor(context, R.color.tapIntroCircleOuter);
+
+                    if (context.getResources().getBoolean(R.bool.use_legacy_intro_colors)) {
+                        int primary = ContextCompat.getColor(context, R.color.toolbarIcon);
+                        int secondary = ColorHelper.setColorAlpha(primary, 0.7f);
+                        titleColor = primary;
+                        descriptionColor = ColorHelper.setColorAlpha(primary, 0.7f);
+                        circleColorInner = secondary;
+                        circleColorOuter = 0;
+                    }
 
                     TapTargetSequence tapTargetSequence = new TapTargetSequence(activity);
                     tapTargetSequence.continueOnCancel(true);
@@ -75,10 +89,14 @@ public class TapIntroHelper {
                         TapTarget tapTarget = TapTarget.forToolbarNavigationIcon(toolbar,
                                 context.getResources().getString(R.string.tap_intro_home_navigation),
                                 context.getResources().getString(R.string.tap_intro_home_navigation_desc))
-                                .titleTextColorInt(primary)
-                                .descriptionTextColorInt(secondary)
-                                .targetCircleColorInt(primary)
+                                .titleTextColorInt(titleColor)
+                                .descriptionTextColorInt(descriptionColor)
+                                .targetCircleColorInt(circleColorInner)
                                 .drawShadow(Preferences.get(context).isTapIntroShadowEnabled());
+
+                        if (circleColorOuter != 0) {
+                            tapTarget.outerCircleColorInt(circleColorOuter);
+                        }
 
                         if (title != null) {
                             tapTarget.textTypeface(title);
@@ -100,19 +118,24 @@ public class TapIntroHelper {
                                     RecyclerView.ViewHolder holder = recyclerView.findViewHolderForAdapterPosition(position);
                                     if (holder != null) {
                                         View view = holder.itemView;
-                                        float targetRadius = toDp(context, view.getMeasuredWidth()) - 20f;
+                                        float circleScale = 1.0f / context.getResources().getInteger(R.integer.tap_intro_circle_scale_percent);
+                                        float targetRadius = (toDp(context, view.getMeasuredWidth()) - 20f) * circleScale;
 
                                         String desc = context.getResources().getString(R.string.tap_intro_home_apply_desc,
                                                 context.getResources().getString(R.string.app_name));
                                         TapTarget tapTarget = TapTarget.forView(view,
                                                 context.getResources().getString(R.string.tap_intro_home_apply),
                                                 desc)
-                                                .titleTextColorInt(primary)
-                                                .descriptionTextColorInt(secondary)
-                                                .targetCircleColorInt(primary)
+                                                .titleTextColorInt(titleColor)
+                                                .descriptionTextColorInt(descriptionColor)
+                                                .targetCircleColorInt(circleColorInner)
                                                 .targetRadius((int) targetRadius)
                                                 .tintTarget(false)
                                                 .drawShadow(Preferences.get(context).isTapIntroShadowEnabled());
+
+                                        if (circleColorOuter != 0) {
+                                            tapTarget.outerCircleColorInt(circleColorOuter);
+                                        }
 
                                         if (title != null) {
                                             tapTarget.textTypeface(title);
@@ -165,18 +188,33 @@ public class TapIntroHelper {
 
             new Handler().postDelayed(() -> {
                 try {
-                    int primary = ContextCompat.getColor(context, R.color.toolbarIcon);
-                    int secondary = ColorHelper.setColorAlpha(primary, 0.7f);
+                    int titleColor = ContextCompat.getColor(context, R.color.tapIntroTitle);
+                    int descriptionColor = ContextCompat.getColor(context, R.color.tapIntroDescription);
+                    int circleColorInner = ContextCompat.getColor(context, R.color.tapIntroCircleInner);
+                    int circleColorOuter = ContextCompat.getColor(context, R.color.tapIntroCircleOuter);
+
+                    if (context.getResources().getBoolean(R.bool.use_legacy_intro_colors)) {
+                        int primary = ContextCompat.getColor(context, R.color.toolbarIcon);
+                        int secondary = ColorHelper.setColorAlpha(primary, 0.7f);
+                        titleColor = primary;
+                        descriptionColor = ColorHelper.setColorAlpha(primary, 0.7f);
+                        circleColorInner = secondary;
+                        circleColorOuter = 0;
+                    }
 
                     Typeface title = TypefaceHelper.getMedium(context);
 
                     TapTarget tapTarget = TapTarget.forToolbarMenuItem(toolbar, R.id.menu_search,
                             context.getResources().getString(R.string.tap_intro_icons_search),
                             context.getResources().getString(R.string.tap_intro_icons_search_desc))
-                            .titleTextColorInt(primary)
-                            .descriptionTextColorInt(secondary)
-                            .targetCircleColorInt(primary)
+                            .titleTextColorInt(titleColor)
+                            .descriptionTextColorInt(descriptionColor)
+                            .targetCircleColorInt(circleColorInner)
                             .drawShadow(Preferences.get(context).isTapIntroShadowEnabled());
+
+                    if (circleColorOuter != 0) {
+                        tapTarget.outerCircleColorInt(circleColorOuter);
+                    }
 
                     if (title != null) {
                         tapTarget.textTypeface(title);
@@ -216,8 +254,19 @@ public class TapIntroHelper {
 
             new Handler().postDelayed(() -> {
                 try {
-                    int primary = ContextCompat.getColor(context, R.color.toolbarIcon);
-                    int secondary = ColorHelper.setColorAlpha(primary, 0.7f);
+                    int titleColor = ContextCompat.getColor(context, R.color.tapIntroTitle);
+                    int descriptionColor = ContextCompat.getColor(context, R.color.tapIntroDescription);
+                    int circleColorInner = ContextCompat.getColor(context, R.color.tapIntroCircleInner);
+                    int circleColorOuter = ContextCompat.getColor(context, R.color.tapIntroCircleOuter);
+
+                    if (context.getResources().getBoolean(R.bool.use_legacy_intro_colors)) {
+                        int primary = ContextCompat.getColor(context, R.color.toolbarIcon);
+                        int secondary = ColorHelper.setColorAlpha(primary, 0.7f);
+                        titleColor = primary;
+                        descriptionColor = ColorHelper.setColorAlpha(primary, 0.7f);
+                        circleColorInner = secondary;
+                        circleColorOuter = 0;
+                    }
 
                     TapTargetSequence tapTargetSequence = new TapTargetSequence(activity);
                     tapTargetSequence.continueOnCancel(true);
@@ -239,10 +288,14 @@ public class TapIntroHelper {
                                         TapTarget tapTarget = TapTarget.forView(view,
                                                 context.getResources().getString(R.string.tap_intro_request_select),
                                                 context.getResources().getString(R.string.tap_intro_request_select_desc))
-                                                .titleTextColorInt(primary)
-                                                .descriptionTextColorInt(secondary)
-                                                .targetCircleColorInt(primary)
+                                                .titleTextColorInt(titleColor)
+                                                .descriptionTextColorInt(descriptionColor)
+                                                .targetCircleColorInt(circleColorInner)
                                                 .drawShadow(Preferences.get(context).isTapIntroShadowEnabled());
+
+                                        if (circleColorOuter != 0) {
+                                            tapTarget.outerCircleColorInt(circleColorOuter);
+                                        }
 
                                         if (title != null) {
                                             tapTarget.textTypeface(title);
@@ -263,10 +316,14 @@ public class TapIntroHelper {
                         TapTarget tapTarget = TapTarget.forToolbarMenuItem(toolbar, R.id.menu_select_all,
                                 context.getResources().getString(R.string.tap_intro_request_select_all),
                                 context.getResources().getString(R.string.tap_intro_request_select_all_desc))
-                                .titleTextColorInt(primary)
-                                .descriptionTextColorInt(secondary)
-                                .targetCircleColorInt(primary)
+                                .titleTextColorInt(titleColor)
+                                .descriptionTextColorInt(descriptionColor)
+                                .targetCircleColorInt(circleColorInner)
                                 .drawShadow(Preferences.get(context).isTapIntroShadowEnabled());
+
+                        if (circleColorOuter != 0) {
+                            tapTarget.outerCircleColorInt(circleColorOuter);
+                        }
 
                         if (title != null) {
                             tapTarget.textTypeface(title);
@@ -284,11 +341,15 @@ public class TapIntroHelper {
                         TapTarget tapTarget = TapTarget.forView(fab,
                                 context.getResources().getString(R.string.tap_intro_request_send),
                                 context.getResources().getString(R.string.tap_intro_request_send_desc))
-                                .titleTextColorInt(primary)
-                                .descriptionTextColorInt(secondary)
-                                .targetCircleColorInt(primary)
+                                .titleTextColorInt(titleColor)
+                                .descriptionTextColorInt(descriptionColor)
+                                .targetCircleColorInt(circleColorInner)
                                 .tintTarget(false)
                                 .drawShadow(Preferences.get(context).isTapIntroShadowEnabled());
+
+                        if (circleColorOuter != 0) {
+                            tapTarget.outerCircleColorInt(circleColorOuter);
+                        }
 
                         if (title != null) {
                             tapTarget.textTypeface(title);
@@ -313,17 +374,22 @@ public class TapIntroHelper {
                                         if (holder != null) {
                                             View view = holder.itemView.findViewById(R.id.buy);
                                             if (view != null) {
-                                                float targetRadius = toDp(context, view.getMeasuredWidth()) - 10f;
+                                                float circleScale = 1.0f / context.getResources().getInteger(R.integer.tap_intro_circle_scale_percent);
+                                                float targetRadius = (toDp(context, view.getMeasuredWidth()) - 10f) * circleScale;
 
                                                 TapTarget tapTarget = TapTarget.forView(view,
                                                         context.getResources().getString(R.string.tap_intro_request_premium),
                                                         context.getResources().getString(R.string.tap_intro_request_premium_desc))
-                                                        .titleTextColorInt(primary)
-                                                        .descriptionTextColorInt(secondary)
-                                                        .targetCircleColorInt(primary)
+                                                        .titleTextColorInt(titleColor)
+                                                        .descriptionTextColorInt(descriptionColor)
+                                                        .targetCircleColorInt(circleColorInner)
                                                         .targetRadius((int) targetRadius)
                                                         .tintTarget(false)
                                                         .drawShadow(Preferences.get(context).isTapIntroShadowEnabled());
+
+                                                if (circleColorOuter != 0) {
+                                                    tapTarget.outerCircleColorInt(circleColorOuter);
+                                                }
 
                                                 if (title != null) {
                                                     tapTarget.textTypeface(title);
@@ -377,8 +443,19 @@ public class TapIntroHelper {
             }
 
             new Handler().postDelayed(() -> {
-                int primary = ContextCompat.getColor(context, R.color.toolbarIcon);
-                int secondary = ColorHelper.setColorAlpha(primary, 0.7f);
+                int titleColor = ContextCompat.getColor(context, R.color.tapIntroTitle);
+                int descriptionColor = ContextCompat.getColor(context, R.color.tapIntroDescription);
+                int circleColorInner = ContextCompat.getColor(context, R.color.tapIntroCircleInner);
+                int circleColorOuter = ContextCompat.getColor(context, R.color.tapIntroCircleOuter);
+
+                if (context.getResources().getBoolean(R.bool.use_legacy_intro_colors)) {
+                    int primary = ContextCompat.getColor(context, R.color.toolbarIcon);
+                    int secondary = ColorHelper.setColorAlpha(primary, 0.7f);
+                    titleColor = primary;
+                    descriptionColor = ColorHelper.setColorAlpha(primary, 0.7f);
+                    circleColorInner = secondary;
+                    circleColorOuter = 0;
+                }
 
                 if (recyclerView != null) {
                     TapTargetSequence tapTargetSequence = new TapTargetSequence(activity);
@@ -395,7 +472,8 @@ public class TapIntroHelper {
 
                         View view = holder.itemView.findViewById(R.id.image);
                         if (view != null) {
-                            float targetRadius = toDp(context, view.getMeasuredWidth()) - 10f;
+                            float circleScale = 1.0f / context.getResources().getInteger(R.integer.tap_intro_circle_scale_percent);
+                            float targetRadius = (toDp(context, view.getMeasuredWidth()) - 10f) * circleScale;
 
                             Typeface title = TypefaceHelper.getMedium(context);
 
@@ -406,9 +484,9 @@ public class TapIntroHelper {
                             TapTarget tapTarget = TapTarget.forView(view,
                                     context.getResources().getString(R.string.tap_intro_wallpapers_option),
                                     desc)
-                                    .titleTextColorInt(primary)
-                                    .descriptionTextColorInt(secondary)
-                                    .targetCircleColorInt(primary)
+                                    .titleTextColorInt(titleColor)
+                                    .descriptionTextColorInt(descriptionColor)
+                                    .targetCircleColorInt(circleColorInner)
                                     .targetRadius((int) targetRadius)
                                     .tintTarget(false)
                                     .drawShadow(Preferences.get(context).isTapIntroShadowEnabled());
@@ -416,12 +494,17 @@ public class TapIntroHelper {
                             TapTarget tapTarget1 = TapTarget.forView(view,
                                     context.getResources().getString(R.string.tap_intro_wallpapers_preview),
                                     context.getResources().getString(R.string.tap_intro_wallpapers_preview_desc))
-                                    .titleTextColorInt(primary)
-                                    .descriptionTextColorInt(secondary)
-                                    .targetCircleColorInt(primary)
+                                    .titleTextColorInt(titleColor)
+                                    .descriptionTextColorInt(descriptionColor)
+                                    .targetCircleColorInt(circleColorInner)
                                     .targetRadius((int) targetRadius)
                                     .tintTarget(false)
                                     .drawShadow(Preferences.get(context).isTapIntroShadowEnabled());
+
+                            if (circleColorOuter != 0) {
+                                tapTarget.outerCircleColorInt(circleColorOuter);
+                                tapTarget1.outerCircleColorInt(circleColorOuter);
+                            }
 
                             if (title != null) {
                                 tapTarget.textTypeface(title);
@@ -470,13 +553,26 @@ public class TapIntroHelper {
 
             new Handler().postDelayed(() -> {
                 try {
-                    int baseColor = color;
-                    if (baseColor == 0) {
-                        baseColor = ColorHelper.getAttributeColor(context, R.attr.colorSecondary);
+                    int circleColorOuter = color;
+                    if (circleColorOuter == 0) {
+                        circleColorOuter = ContextCompat.getColor(context, R.color.tapIntroCircleOuter);
                     }
 
-                    int primary = ColorHelper.getTitleTextColor(baseColor);
-                    int secondary = ColorHelper.setColorAlpha(primary, 0.7f);
+                    int titleColor = ContextCompat.getColor(context, R.color.tapIntroTitle);
+                    int descriptionColor = ContextCompat.getColor(context, R.color.tapIntroDescription);
+                    int circleColorInner = ContextCompat.getColor(context, R.color.tapIntroCircleInner);
+
+                    if (context.getResources().getBoolean(R.bool.use_legacy_intro_colors)) {
+                        int primary = ContextCompat.getColor(context, R.color.toolbarIcon);
+                        int secondary = ColorHelper.setColorAlpha(primary, 0.7f);
+                        titleColor = primary;
+                        descriptionColor = ColorHelper.setColorAlpha(primary, 0.7f);
+                        circleColorInner = secondary;
+                        circleColorOuter = ColorHelper.setColorAlpha(
+                                ColorHelper.getAttributeColor(context, R.attr.colorSecondary),
+                                0.7f
+                        );
+                    }
 
                     TapTargetSequence tapTargetSequence = new TapTargetSequence(activity);
                     tapTargetSequence.continueOnCancel(true);
@@ -491,20 +587,20 @@ public class TapIntroHelper {
                     TapTarget tapTarget = TapTarget.forView(apply,
                             context.getResources().getString(R.string.tap_intro_wallpaper_preview_apply),
                             context.getResources().getString(R.string.tap_intro_wallpaper_preview_apply_desc))
-                            .titleTextColorInt(primary)
-                            .descriptionTextColorInt(secondary)
-                            .targetCircleColorInt(primary)
-                            .outerCircleColorInt(baseColor)
-                            .drawShadow(true);
+                            .titleTextColorInt(titleColor)
+                            .descriptionTextColorInt(descriptionColor)
+                            .targetCircleColorInt(circleColorInner)
+                            .outerCircleColorInt(circleColorOuter)
+                            .drawShadow(Preferences.get(context).isTapIntroShadowEnabled());
 
                     TapTarget tapTarget1 = TapTarget.forView(save,
                             context.getResources().getString(R.string.tap_intro_wallpaper_preview_save),
                             context.getResources().getString(R.string.tap_intro_wallpaper_preview_save_desc))
-                            .titleTextColorInt(primary)
-                            .descriptionTextColorInt(secondary)
-                            .targetCircleColorInt(primary)
-                            .outerCircleColorInt(baseColor)
-                            .drawShadow(true);
+                            .titleTextColorInt(titleColor)
+                            .descriptionTextColorInt(descriptionColor)
+                            .targetCircleColorInt(circleColorInner)
+                            .outerCircleColorInt(circleColorOuter)
+                            .drawShadow(Preferences.get(context).isTapIntroShadowEnabled());
 
                     if (title != null) {
                         //Todo:

--- a/library/src/main/res/values/colors.xml
+++ b/library/src/main/res/values/colors.xml
@@ -38,6 +38,12 @@
     <!-- Swipe Refresh -->
     <color name="swipeRefresh">#20AC6B</color>
 
+    <!-- Tap Intro -->
+    <color name="tapIntroTitle">@color/mainBackground</color>
+    <color name="tapIntroDescription">@color/mainBackground</color>
+    <color name="tapIntroCircleInner">@color/primaryText</color>
+    <color name="tapIntroCircleOuter">@color/secondaryText</color>
+
     <!-- Toolbar -->
     <color name="toolbarIcon">#FFFFFFFF</color>
     <color name="toolbarIconDark">#FFFFFFFF</color>

--- a/library/src/main/res/values/dashboard_configurations.xml
+++ b/library/src/main/res/values/dashboard_configurations.xml
@@ -326,6 +326,14 @@
 
     <!-- Show intro guides on first run -->
     <bool name="show_intro">false</bool>
+    <!-- Use the set of predefined colours for the tap intro
+        This used to be the default. If set to false, you can
+        override colors with these attributes in colors.xml:
+            tapIntroTitle
+            tapIntroDescription
+            tapIntroCircleInner
+            tapIntroCircleOuter -->
+    <bool name="use_legacy_intro_colors">true</bool>
 
     <!-- These are not documented. As you can guess, these are not for general use -->
     <string name="appfilter_item"><![CDATA[<item component=\"ComponentInfo{{{component}}}\" drawable=\"{{drawable}}\" />]]></string>

--- a/library/src/main/res/values/integers.xml
+++ b/library/src/main/res/values/integers.xml
@@ -10,4 +10,5 @@
 
     <integer name="about_column_count">1</integer>
 
+    <integer name="tap_intro_circle_scale_percent">100</integer>
 </resources>


### PR DESCRIPTION
This commit adds six additional parameters to configure:

Colors:
 * `tapIntroTitle`
 * `tapIntroDescription`
 * `tapIntroCircleInner`
 * `tapIntroCircleOuter`

Boolean:
 * `use_legacy_intro_colors` (defaults to `true`)

Integer:
 * `tap_intro_circle_scale_percent` (defaults to 100%)

The default behaviour for CandyBar users does not change. Those who want to customise the tap intro colours, can turn the default behaviour off with `use_legacy_intro_colors=false` and then go on to specify custom colours with the 4 color values.

Also, a scale factor has been added for the tap intro circles. It will be taken as-is and will multiply the default values accordingly to increase or decrease the size of the outer circle.