### PR TITLE
Fix handling of VectorDrawable in icon requests

### DIFF
--- a/library/src/main/java/candybar/lib/adapters/RequestAdapter.java
+++ b/library/src/main/java/candybar/lib/adapters/RequestAdapter.java
@@ -186,7 +186,7 @@ public class RequestAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder
 
             if (CandyBarGlideModule.isValidContextForGlide(mContext)) {
                 Glide.with(mContext)
-                        .load("package://" + mRequests.get(finalPosition).getActivity())
+                        .load(candybar.lib.helpers.DrawableHelper.getReqIcon(mContext, mRequests.get(finalPosition).getActivity()))
                         .override(272)
                         .transition(DrawableTransitionOptions.withCrossFade(300))
                         .diskCacheStrategy(DiskCacheStrategy.NONE)

--- a/library/src/main/java/candybar/lib/helpers/DrawableHelper.java
+++ b/library/src/main/java/candybar/lib/helpers/DrawableHelper.java
@@ -8,10 +8,12 @@ import android.content.pm.PackageManager;
 import android.content.pm.ResolveInfo;
 import android.content.res.Resources;
 import android.graphics.Bitmap;
+import android.graphics.Canvas;
 import android.graphics.Color;
 import android.graphics.drawable.AdaptiveIconDrawable;
 import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.Drawable;
+import android.graphics.drawable.VectorDrawable;
 import android.os.Build;
 import android.util.Base64;
 import android.util.DisplayMetrics;
@@ -112,6 +114,14 @@ public class DrawableHelper {
                 return new AdaptiveIcon()
                         .setDrawable((AdaptiveIconDrawable) drawable)
                         .render();
+            } else if (drawable instanceof VectorDrawable) {
+                Bitmap bitmap = Bitmap.createBitmap(
+                        drawable.getIntrinsicWidth(),
+                        drawable.getIntrinsicHeight(), Bitmap.Config.ARGB_8888);
+                Canvas canvas = new Canvas(bitmap);
+                drawable.setBounds(0, 0, canvas.getWidth(), canvas.getHeight());
+                drawable.draw(canvas);
+                return bitmap;
             }
         }
         return null;


### PR DESCRIPTION
This commit changes the way unthemed icons (for display in the icon requests section) are loaded by Glide. Where it would previously load by package name (presumably using a custom resource but I didn't find it), it's now getting the drawable directly. This fixes `VectorDrawables` going unhandled and showing up as blank.

Similarly, `getRightIcon` returning `null` would cause the user to get stuck on the `Building request...` dialog when they would try to submit an icon request containing a `VectorDrawable`. This is a problem in and of itself (e.g. if new drawable types come up) but I chose to go the way of least resistance and simply add a handler for `VectorDrawable` specifically.

Fixes #119