### PR TITLE
Add support for visibly disabled requests

### DIFF
--- a/library/src/main/java/candybar/lib/adapters/RequestAdapter.java
+++ b/library/src/main/java/candybar/lib/adapters/RequestAdapter.java
@@ -482,7 +482,7 @@ public class RequestAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder
                             .typeface(TypefaceHelper.getMedium(mContext), TypefaceHelper.getRegular(mContext))
                             .title(mContext.getResources().getString(R.string.request_not_available))
                             .content(mRequests.get(position).getInfoText())
-                            .negativeText(android.R.string.cancel)
+                            .positiveText(android.R.string.yes)
                             .show();
                 }
                 return false;

--- a/library/src/main/java/candybar/lib/adapters/RequestAdapter.java
+++ b/library/src/main/java/candybar/lib/adapters/RequestAdapter.java
@@ -17,9 +17,11 @@ import android.widget.TextView;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.appcompat.content.res.AppCompatResources;
 import androidx.recyclerview.widget.RecyclerView;
 import androidx.recyclerview.widget.StaggeredGridLayoutManager;
 
+import com.afollestad.materialdialogs.MaterialDialog;
 import com.bumptech.glide.Glide;
 import com.bumptech.glide.load.engine.DiskCacheStrategy;
 import com.bumptech.glide.load.resource.drawable.DrawableTransitionOptions;
@@ -33,6 +35,7 @@ import java.util.List;
 
 import candybar.lib.R;
 import candybar.lib.applications.CandyBarApplication;
+import candybar.lib.helpers.TypefaceHelper;
 import candybar.lib.items.Request;
 import candybar.lib.preferences.Preferences;
 import candybar.lib.utils.CandyBarGlideModule;
@@ -194,14 +197,43 @@ public class RequestAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder
             }
 
             contentViewHolder.title.setText(mRequests.get(finalPosition).getName());
+            contentViewHolder.infoIcon.setVisibility(View.GONE);
 
             if (mRequests.get(finalPosition).isRequested()) {
                 contentViewHolder.content.setTextColor(mTextColorAccent);
                 contentViewHolder.content.setText(mContext.getResources().getString(
                         R.string.request_already_requested));
-            } else {
+            } else if (mRequests.get(finalPosition).isAvailableForRequest()) {
                 contentViewHolder.content.setText(mContext.getResources().getString(
                         R.string.request_not_requested));
+            } else {
+                contentViewHolder.content.setText(mContext.getResources().getString(
+                        R.string.request_not_available));
+            }
+
+            if (!mRequests.get(finalPosition).isAvailableForRequest()) {
+                contentViewHolder.content.setAlpha(0.5f);
+                contentViewHolder.title.setAlpha(0.5f);
+                contentViewHolder.icon.setAlpha(0.5f);
+                contentViewHolder.checkbox.setEnabled(false);
+            } else {
+                contentViewHolder.content.setAlpha(1f);
+                contentViewHolder.title.setAlpha(1f);
+                contentViewHolder.icon.setAlpha(1f);
+                contentViewHolder.checkbox.setEnabled(true);
+            }
+
+            if (!mRequests.get(finalPosition).getInfoText().isEmpty()) {
+                contentViewHolder.infoIcon.setVisibility(View.VISIBLE);
+                contentViewHolder.infoIcon.setImageDrawable(AppCompatResources.getDrawable(mContext, R.drawable.ic_drawer_about));
+                contentViewHolder.infoIcon.setColorFilter(mTextColorSecondary);
+                int pos = finalPosition;
+                contentViewHolder.infoIcon.setOnClickListener(v -> new MaterialDialog.Builder(mContext)
+                        .typeface(TypefaceHelper.getMedium(mContext), TypefaceHelper.getRegular(mContext))
+                        .title(mRequests.get(pos).getName())
+                        .content(mRequests.get(pos).getInfoText())
+                        .positiveText(android.R.string.yes)
+                        .show());
             }
 
             contentViewHolder.checkbox.setChecked(mSelectedItems.get(finalPosition, false));
@@ -342,6 +374,7 @@ public class RequestAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder
         private final TextView content;
         private final ImageView icon;
         private final CheckBox checkbox;
+        private final ImageView infoIcon;
         private final View divider;
 
         ContentViewHolder(View itemView) {
@@ -350,6 +383,7 @@ public class RequestAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder
             content = itemView.findViewById(R.id.requested);
             icon = itemView.findViewById(R.id.icon);
             checkbox = itemView.findViewById(R.id.checkbox);
+            infoIcon = itemView.findViewById(R.id.requestedInfoIcon);
             LinearLayout container = itemView.findViewById(R.id.container);
             divider = itemView.findViewById(R.id.divider);
 
@@ -442,7 +476,19 @@ public class RequestAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder
         if (position >= 0 && position < mRequests.size()) {
             if (mSelectedItems.get(position, false))
                 mSelectedItems.delete(position);
-            else mSelectedItems.put(position, true);
+            else if (!mRequests.get(position).isAvailableForRequest()) {
+                if (!mRequests.get(position).getInfoText().isEmpty()) {
+                    new MaterialDialog.Builder(mContext)
+                            .typeface(TypefaceHelper.getMedium(mContext), TypefaceHelper.getRegular(mContext))
+                            .title(mContext.getResources().getString(R.string.request_not_available))
+                            .content(mRequests.get(position).getInfoText())
+                            .negativeText(android.R.string.cancel)
+                            .show();
+                }
+                return false;
+            } else {
+                mSelectedItems.put(position, true);
+            }
             try {
                 RequestListener listener = (RequestListener) mContext;
                 listener.onRequestSelected(getSelectedItemsSize());
@@ -462,7 +508,7 @@ public class RequestAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder
 
         mSelectedItems.clear();
         for (int i = 0; i < mRequests.size(); i++) {
-            if (!mRequests.get(i).isRequested())
+            if (!mRequests.get(i).isRequested() && mRequests.get(i).isAvailableForRequest())
                 mSelectedItems.put(i, true);
         }
         mSelectedAll = mSelectedItems.size() > 0;

--- a/library/src/main/java/candybar/lib/items/Request.java
+++ b/library/src/main/java/candybar/lib/items/Request.java
@@ -32,6 +32,8 @@ public class Request {
     private String mRequestedOn;
     private String mIconBase64;
     private boolean mRequested;
+    private boolean mIsAvailableForRequest;
+    private String mInfoText;
 
     private Request(String name, String activity) {
         mName = name;
@@ -74,6 +76,10 @@ public class Request {
 
     public String getIconBase64() { return mIconBase64; }
 
+    public boolean isAvailableForRequest() { return mIsAvailableForRequest; }
+
+    public String getInfoText() { return mInfoText; }
+
     public void setPackageName(String packageName) {
         mPackageName = packageName;
     }
@@ -96,6 +102,10 @@ public class Request {
 
     public void setIconBase64(String iconBase64) { mIconBase64 = iconBase64; }
 
+    public void setAvailableForRequest(boolean isAvailable) { mIsAvailableForRequest = isAvailable; }
+
+    public void setInfoText(String infoText) { mInfoText = infoText; }
+
     public static Builder Builder() {
         return new Builder();
     }
@@ -109,11 +119,15 @@ public class Request {
         private String mProductId;
         private String mRequestedOn;
         private boolean mRequested;
+        private boolean mIsAvailableForRequest;
+        private String mInfoText;
 
         private Builder() {
             mName = "";
             mActivity = "";
             mRequested = false;
+            mIsAvailableForRequest = true;
+            mInfoText = "";
         }
 
         public Builder name(String name) {
@@ -151,6 +165,16 @@ public class Request {
             return this;
         }
 
+        public Builder availableForRequest(boolean available) {
+            mIsAvailableForRequest = available;
+            return this;
+        }
+
+        public Builder infoText(String infoText) {
+            mInfoText = infoText;
+            return this;
+        }
+
         public Request build() {
             Request request = new Request(mName, mActivity);
             request.setPackageName(mPackageName);
@@ -158,6 +182,8 @@ public class Request {
             request.setRequested(mRequested);
             request.setOrderId(mOrderId);
             request.setProductId(mProductId);
+            request.setAvailableForRequest(mIsAvailableForRequest);
+            request.setInfoText(mInfoText);
             return request;
         }
     }

--- a/library/src/main/res/layout-land/fragment_request_item_list.xml
+++ b/library/src/main/res/layout-land/fragment_request_item_list.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/card"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
@@ -55,6 +56,15 @@
                 app:fontFamily="@font/regular" />
 
         </LinearLayout>
+
+        <ImageView
+            android:id="@+id/requestedInfoIcon"
+            android:layout_width="wrap_content"
+            android:layout_height="match_parent"
+            android:src="@drawable/ic_drawer_about"
+            android:scaleX="0.8"
+            android:scaleY="0.8"
+            tools:ignore="ContentDescription" />
 
         <CheckBox
             android:id="@+id/checkbox"

--- a/library/src/main/res/layout-sw600dp/fragment_request_item_list.xml
+++ b/library/src/main/res/layout-sw600dp/fragment_request_item_list.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/card"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
@@ -55,6 +56,15 @@
                 app:fontFamily="@font/regular" />
 
         </LinearLayout>
+
+        <ImageView
+            android:id="@+id/requestedInfoIcon"
+            android:layout_width="wrap_content"
+            android:layout_height="match_parent"
+            android:src="@drawable/ic_drawer_about"
+            android:scaleX="0.8"
+            android:scaleY="0.8"
+            tools:ignore="ContentDescription" />
 
         <CheckBox
             android:id="@+id/checkbox"

--- a/library/src/main/res/layout/fragment_request_item_list.xml
+++ b/library/src/main/res/layout/fragment_request_item_list.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:orientation="vertical"
@@ -48,6 +49,15 @@
                 app:fontFamily="@font/regular" />
 
         </LinearLayout>
+
+        <ImageView
+            android:id="@+id/requestedInfoIcon"
+            android:layout_width="wrap_content"
+            android:layout_height="match_parent"
+            android:src="@drawable/ic_drawer_about"
+            android:scaleX="0.8"
+            android:scaleY="0.8"
+            tools:ignore="ContentDescription" />
 
         <CheckBox
             android:id="@+id/checkbox"

--- a/library/src/main/res/values/dashboard_strings.xml
+++ b/library/src/main/res/values/dashboard_strings.xml
@@ -163,6 +163,7 @@
     <string name="request_not_selected">Select apps to request</string>
     <string name="request_not_requested">Not requested</string>
     <string name="request_already_requested">Already requested</string>
+    <string name="request_not_available">Cannot be requested</string>
 
     <string name="request_building">Building request …</string>
     <string name="request_pacific_sending">Sending request to Pacific Manager...</string>


### PR DESCRIPTION
This commit follows the discussion in https://github.com/zixpo/candybar/discussions/133 and makes more options available to the FilterRequestHandler. In addition to the return value of true/false which completely hides apps from the icon request section, the new methods `setAvailableForRequest()` and `setInfoText()` allow to arbitrarily annotate and disable icons as follows:

When `setInfoText()` sets a non-empty string, a little `(i)` icon will be displayed and upon tapping it, a dialog with `infoText` pops up.

When `setAvailableForRequest()` is set to `false`, the entire item will be greyed out. When tapping it, nothing happens. Unless `setInfoText()` is used as well, in which case a dialog with the `infoText` pops up.

This allows for flexible combinations of selectively hiding, greying out, or just annotating icons based on matched patterns.