### PR TITLE
Associate OneUI with Samsung explicitly

### DIFF
--- a/library/src/main/java/candybar/lib/helpers/LauncherHelper.java
+++ b/library/src/main/java/candybar/lib/helpers/LauncherHelper.java
@@ -173,7 +173,7 @@ public class LauncherHelper {
                 new String[]{"fr.neamar.kiss"},
                 true),
         ONEUI(
-                "One UI",
+                "Samsung One UI",
                 R.drawable.ic_launcher_one_ui,
                 new String[]{"com.sec.android.app.launcher"},
                 false),


### PR DESCRIPTION
A few of my users had trouble identifying OneUI as "their" launcher on their Samsung phones and reached out with questions. I hope by adding "Samsung" to the launcher name this makes it more obvious.