### PR TITLE
Add Material You

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.0.1'
+        classpath 'com.android.tools.build:gradle:8.0.2'
     }
 }
 

--- a/library/src/main/java/candybar/lib/activities/CandyBarMainActivity.java
+++ b/library/src/main/java/candybar/lib/activities/CandyBarMainActivity.java
@@ -38,6 +38,7 @@ import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentManager;
 import androidx.fragment.app.FragmentTransaction;
 
+import com.afollestad.materialdialogs.BuildConfig;
 import com.afollestad.materialdialogs.MaterialDialog;
 import com.android.billingclient.api.AcknowledgePurchaseParams;
 import com.android.billingclient.api.BillingClient;
@@ -54,6 +55,7 @@ import com.danimahardhika.android.helpers.core.utils.LogUtil;
 import com.danimahardhika.android.helpers.license.LicenseHelper;
 import com.danimahardhika.android.helpers.permission.PermissionCode;
 import com.google.android.gms.tasks.Task;
+import com.google.android.material.color.DynamicColors;
 import com.google.android.material.navigation.NavigationView;
 import com.google.android.play.core.review.ReviewInfo;
 import com.google.android.play.core.review.ReviewManager;
@@ -165,16 +167,31 @@ public abstract class CandyBarMainActivity extends AppCompatActivity implements
         final boolean isDarkTheme = prevIsDarkTheme = ThemeHelper.isDarkTheme(this);
 
         final int nightMode;
-        switch (Preferences.get(this).getTheme()) {
-            case LIGHT:
-                nightMode = AppCompatDelegate.MODE_NIGHT_NO;
-                break;
-            case DARK:
-                nightMode = AppCompatDelegate.MODE_NIGHT_YES;
-                break;
-            default:
-                nightMode = AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM;
+        int androidVersion = Build.VERSION.SDK_INT;
+        if (androidVersion < Build.VERSION_CODES.S) {
+            // Android version is less than 12
+            switch (Preferences.get(this).getTheme()) {
+                case LIGHT:
+                    nightMode = AppCompatDelegate.MODE_NIGHT_NO;
+                    break;
+                case DARK:
+                    nightMode = AppCompatDelegate.MODE_NIGHT_YES;
+                    break;
+                case MATERIAL_YOU:
+                    // Display a toast message about Material You availability on Android 12 and up.
+                    Toast.makeText(this, "Material You available only on Android 12 and up!", Toast.LENGTH_SHORT).show();
+                    nightMode = AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM;
+                    break;
+                default:
+                    nightMode = AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM;
+                    break;
+            }
+        } else {
+            // Android version is 12 or higher (including future versions)
+            DynamicColors.applyToActivitiesIfAvailable(this.getApplication());
+            nightMode = AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM;
         }
+
         AppCompatDelegate.setDefaultNightMode(nightMode);
 
         LocaleHelper.setLocale(this);

--- a/library/src/main/java/candybar/lib/activities/CandyBarMainActivity.java
+++ b/library/src/main/java/candybar/lib/activities/CandyBarMainActivity.java
@@ -179,7 +179,7 @@ public abstract class CandyBarMainActivity extends AppCompatActivity implements
                     break;
                 case MATERIAL_YOU:
                     // Display a toast message about Material You availability on Android 12 and up.
-                    Toast.makeText(this, "Material You available only on Android 12 and up!", Toast.LENGTH_SHORT).show();
+                    Toast.makeText(this, "Material You available only on Android 12 and up! \n Following system theme...", Toast.LENGTH_SHORT).show();
                     nightMode = AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM;
                     break;
                 default:
@@ -187,11 +187,22 @@ public abstract class CandyBarMainActivity extends AppCompatActivity implements
                     break;
             }
         } else {
-            // Android version is 12 or higher (including future versions)
-            DynamicColors.applyToActivitiesIfAvailable(this.getApplication());
-            nightMode = AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM;
+            switch (Preferences.get(this).getTheme()) {
+                case LIGHT:
+                    nightMode = AppCompatDelegate.MODE_NIGHT_NO;
+                    break;
+                case DARK:
+                    nightMode = AppCompatDelegate.MODE_NIGHT_YES;
+                    break;
+                case MATERIAL_YOU:
+                    DynamicColors.applyToActivitiesIfAvailable(this.getApplication());
+                    nightMode = AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM;
+                    break;
+                default:
+                    nightMode = AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM;
+                    break;
+            }
         }
-
         AppCompatDelegate.setDefaultNightMode(nightMode);
 
         LocaleHelper.setLocale(this);

--- a/library/src/main/java/candybar/lib/items/Theme.java
+++ b/library/src/main/java/candybar/lib/items/Theme.java
@@ -9,7 +9,8 @@ import candybar.lib.R;
 public enum Theme {
     AUTO(R.string.theme_name_auto),
     LIGHT(R.string.theme_name_light),
-    DARK(R.string.theme_name_dark);
+    DARK(R.string.theme_name_dark),
+    MATERIAL_YOU(R.string.theme_name_material_you);
 
     private final int nameStringRes;
 

--- a/library/src/main/res/values-night-v31/colors.xml
+++ b/library/src/main/res/values-night-v31/colors.xml
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <!--
+        Try to not reference other theme colors, or it may result in
+        an error (android.view.InflateException)
+
+        If you want to reuse colors using referencing, just create a
+        new color and reference it. Do not try to reference existing
+        theme colors.
+        Example -
+        ```
+        Declaring the color
+        <color name="common_color">#FFF</color>
+
+        Referencing the common color
+        <color name="someColor">@color/common_color</color>
+        <color name="anotherColor">@color/common_color</color>
+        ```
+    -->
+
+    <color name="colorPrimary">@android:color/system_neutral1_900</color>
+    <color name="colorPrimaryDark">@android:color/system_neutral1_900</color>
+    <color name="colorAccent">@android:color/system_accent3_300</color>
+
+    <color name="darkColorPrimary">@android:color/system_neutral1_900</color>
+    <color name="darkColorPrimaryDark">@android:color/system_neutral1_900</color>
+    <color name="darkColorAccent">@android:color/system_accent3_300</color>
+
+    <!-- Shortcut Icon -->
+    <color name="shortcutIconBackground">#000000</color>
+    <color name="shortcutIconForeground">@android:color/system_accent1_100</color>
+
+    <!-- Navigation Bar
+    * Must be solid color, no alpha -->
+    <color name="navigationBar">@android:color/system_neutral1_900</color>
+    <color name="navigationBarDark">@android:color/system_neutral1_900</color>
+
+    <!-- Splash Screen -->
+    <color name="splashColor">@android:color/system_neutral1_900</color>
+
+    <!-- Navigation View -->
+    <color name="navigationViewHeaderBackground">#00FFFFFF</color>
+    <color name="navigationViewHeaderBackgroundDark">#00FFFFFF</color>
+    <color name="navigationViewTitle">@android:color/system_accent1_100</color>
+    <color name="navigationViewTitleBack">#00000000</color>
+
+    <color name="navigationViewText">@android:color/system_accent2_200</color>
+    <color name="navigationViewTextDark">@android:color/system_accent2_200</color>
+    <color name="navigationViewTextSelected">@android:color/system_accent2_50</color>
+    <color name="navigationViewTextSelectedDark">@android:color/system_accent2_50</color>
+    <color name="navigationViewSelectedBackground">@android:color/system_accent1_900</color>
+    <color name="navigationViewSelectedBackgroundDark">@android:color/system_accent1_900</color>
+
+    <!-- Swipe Refresh -->
+    <color name="swipeRefresh">@android:color/system_accent1_100</color>
+
+    <!-- Toolbar -->
+    <color name="toolbarIcon">@android:color/system_accent1_100</color>
+    <color name="toolbarIconDark">@android:color/system_accent1_100</color>
+
+    <!-- Tab -->
+    <color name="tabIndicator">@android:color/system_neutral1_300</color>
+    <color name="tabIndicatorDark">@android:color/system_neutral1_300</color>
+    <color name="tabText">@android:color/system_neutral1_100</color>
+    <color name="tabTextDark">@android:color/system_neutral1_100</color>
+    <color name="tabTextSelected">@android:color/system_neutral1_100</color>
+    <color name="tabTextSelectedDark">@android:color/system_neutral1_100</color>
+
+    <!-- Card -->
+    <color name="cardBackground">@android:color/system_accent1_800</color>
+    <color name="cardBackgroundDark">@android:color/system_accent1_800</color>
+    <color name="cardStroke">@android:color/system_accent1_800</color>
+    <color name="cardStrokeDark">@android:color/system_accent1_800</color>
+
+    <!-- Ripple -->
+    <color name="rippleColor">@android:color/system_accent1_700</color>
+    <color name="rippleColorDark">@android:color/system_accent1_700</color>
+    <color name="rippleAccent">@android:color/system_accent1_700</color>
+    <color name="rippleAccentDark">@android:color/system_accent1_700</color>
+
+    <!-- Attributes -->
+    <color name="mainBackground">@android:color/system_neutral1_900</color>
+    <color name="mainBackgroundDark">@android:color/system_neutral1_900</color>
+    <color name="primaryText">@android:color/system_accent2_50</color>
+    <color name="primaryTextDark">@android:color/system_accent2_50</color>
+    <color name="secondaryText">@android:color/system_accent2_100</color>
+    <color name="secondaryTextDark">@android:color/system_accent2_100</color>
+
+    <color name="dividerList">@android:color/system_accent1_900</color>
+    <color name="dividerListDark">@android:color/system_accent1_900</color>
+
+    <!-- Wallpaper Preview -->
+    <color name="wallpaperStatusBar">#000000</color>
+    <color name="wallpaperToolbar">#000000</color>
+
+    <!-- Home Graphic -->
+    <color name="icon_home_color">@android:color/system_accent1_500</color>
+    <color name="icon_home_background_color">@android:color/system_accent1_100</color>
+
+    <!-- Icons -->
+    <color name="icon_color">@android:color/system_accent1_100</color>
+    <color name="icon_background_color">@android:color/system_accent1_800</color>
+
+    <!-- Clock -->
+    <color name="clockColor">@android:color/system_accent1_100</color>
+</resources>

--- a/library/src/main/res/values-v21/themes.xml
+++ b/library/src/main/res/values-v21/themes.xml
@@ -1,6 +1,6 @@
 <resources>
 
-    <style name="CandyBar.Theme.Base" parent="Theme.MaterialComponents.DayNight.NoActionBar">
+    <style name="CandyBar.Theme.Base" parent="Theme.Material3.DayNight.NoActionBar">
         <item name="android:windowActivityTransitions">true</item>
         <item name="android:windowAnimationStyle">@style/WindowAnimationTransition</item>
 
@@ -11,7 +11,7 @@
         <item name="android:windowSharedElementExitTransition">@android:transition/move</item>
     </style>
 
-    <style name="CandyBar.Theme.Splash" parent="Theme.MaterialComponents.DayNight">
+    <style name="CandyBar.Theme.Splash" parent="Theme.Material3.DayNight">
         <item name="windowNoTitle">true</item>
         <item name="windowActionBar">false</item>
         <item name="android:windowNoTitle">true</item>

--- a/library/src/main/res/values-v31/colors.xml
+++ b/library/src/main/res/values-v31/colors.xml
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <!--
+        Try to not reference other theme colors, or it may result in
+        an error (android.view.InflateException)
+
+        If you want to reuse colors using referencing, just create a
+        new color and reference it. Do not try to reference existing
+        theme colors.
+        Example -
+        ```
+        Declaring the color
+        <color name="common_color">#FFF</color>
+
+        Referencing the common color
+        <color name="someColor">@color/common_color</color>
+        <color name="anotherColor">@color/common_color</color>
+        ```
+    -->
+
+    <color name="colorPrimary">@android:color/system_neutral1_50</color>
+    <color name="colorPrimaryDark">@android:color/system_neutral1_200</color>
+    <color name="colorAccent">@android:color/system_accent3_600</color>
+
+    <color name="darkColorPrimary">@android:color/system_neutral1_800</color>
+    <color name="darkColorPrimaryDark">@android:color/system_neutral1_800</color>
+    <color name="darkColorAccent">@android:color/system_accent3_700</color>
+
+    <!-- Shortcut Icon -->
+    <color name="shortcutIconBackground">#000000</color>
+    <color name="shortcutIconForeground">@android:color/system_accent1_900</color>
+
+    <!-- Navigation Bar
+    * Must be solid color, no alpha -->
+    <color name="navigationBar">@android:color/system_accent1_10</color>
+    <color name="navigationBarDark">@android:color/system_accent1_10</color>
+
+    <!-- Splash Screen -->
+    <color name="splashColor">@android:color/system_accent1_50</color>
+
+    <!-- Navigation View -->
+    <color name="navigationViewHeaderBackground">#00FFFFFF</color>
+    <color name="navigationViewHeaderBackgroundDark">#00FFFFFF</color>
+    <color name="navigationViewTitle">@android:color/system_accent1_900</color>
+    <color name="navigationViewTitleBack">#00000000</color>
+
+    <color name="navigationViewText">@android:color/system_accent2_900</color>
+    <color name="navigationViewTextDark">@android:color/system_accent2_900</color>
+    <color name="navigationViewTextSelected">@android:color/system_accent2_900</color>
+    <color name="navigationViewTextSelectedDark">@android:color/system_accent2_900</color>
+    <color name="navigationViewSelectedBackground">@android:color/system_accent1_10</color>
+    <color name="navigationViewSelectedBackgroundDark">@android:color/system_accent1_10</color>
+
+    <!-- Swipe Refresh -->
+    <color name="swipeRefresh">@android:color/system_accent1_900</color>
+
+    <!-- Toolbar -->
+    <color name="toolbarIcon">@android:color/system_accent2_900</color>
+    <color name="toolbarIconDark">@android:color/system_accent2_900</color>
+
+    <!-- Tab -->
+    <color name="tabIndicator">@android:color/system_accent3_700</color>
+    <color name="tabIndicatorDark">@android:color/system_accent3_700</color>
+    <color name="tabText">@android:color/system_accent1_900</color>
+    <color name="tabTextDark">@android:color/system_accent1_900</color>
+    <color name="tabTextSelected">@android:color/system_accent1_900</color>
+    <color name="tabTextSelectedDark">@android:color/system_accent1_900</color>
+
+    <!-- Card -->
+    <color name="cardBackground">@android:color/system_accent1_100</color>
+    <color name="cardBackgroundDark">@android:color/system_accent1_100</color>
+    <color name="cardStroke">@android:color/system_accent2_50</color>
+    <color name="cardStrokeDark">@android:color/system_accent2_50</color>
+
+    <!-- Ripple -->
+    <color name="rippleColor">@android:color/system_accent1_100</color>
+    <color name="rippleColorDark">@android:color/system_accent1_300</color>
+    <color name="rippleAccent">@android:color/system_accent1_100</color>
+    <color name="rippleAccentDark">@android:color/system_accent1_300</color>
+
+    <!-- Attributes -->
+    <color name="mainBackground">@android:color/system_neutral1_50</color>
+    <color name="mainBackgroundDark">@android:color/system_neutral1_50</color>
+    <color name="primaryText">@android:color/system_accent2_900</color>
+    <color name="primaryTextDark">@android:color/system_accent2_900</color>
+    <color name="secondaryText">@android:color/system_accent2_900</color>
+    <color name="secondaryTextDark">@android:color/system_accent2_900</color>
+
+    <color name="dividerList">@android:color/system_accent1_200</color>
+    <color name="dividerListDark">@android:color/system_accent1_200</color>
+
+    <!-- Wallpaper Preview -->
+    <color name="wallpaperStatusBar">#000000</color>
+    <color name="wallpaperToolbar">#000000</color>
+
+    <!-- Home Graphic -->
+    <color name="icon_home_color">@android:color/system_accent1_100</color>
+    <color name="icon_home_background_color">@android:color/system_accent1_500</color>
+
+    <!-- Icons -->
+    <color name="icon_color">@android:color/system_accent1_800</color>
+    <color name="icon_background_color">@android:color/system_accent1_100</color>
+
+    <!-- Clock -->
+    <color name="clockColor">@android:color/system_accent1_800</color>
+</resources>

--- a/library/src/main/res/values/dashboard_strings.xml
+++ b/library/src/main/res/values/dashboard_strings.xml
@@ -291,6 +291,7 @@
     <string name="theme_name_auto">Auto</string>
     <string name="theme_name_light">Light</string>
     <string name="theme_name_dark">Dark</string>
+    <string name="theme_name_material_you">Material You</string>
 
     <!-- Permission -->
     <string name="permission_storage_denied">Storage permission needed to save wallpaper</string>

--- a/library/src/main/res/values/styles.xml
+++ b/library/src/main/res/values/styles.xml
@@ -36,7 +36,7 @@
         <item name="colorControlNormal">@color/toolbarIcon</item>
     </style>
 
-    <style name="ToolbarStyle" parent="Widget.MaterialComponents.Toolbar">
+    <style name="ToolbarStyle" parent="Widget.Material3.Toolbar">
         <item name="materialThemeOverlay">@style/ToolbarThemeOverlay</item>
     </style>
 

--- a/library/src/main/res/values/styles.xml
+++ b/library/src/main/res/values/styles.xml
@@ -36,7 +36,7 @@
         <item name="colorControlNormal">@color/toolbarIcon</item>
     </style>
 
-    <style name="ToolbarStyle" parent="Widget.Material3.Toolbar">
+    <style name="ToolbarStyle" parent="Widget.MaterialComponents.Toolbar">
         <item name="materialThemeOverlay">@style/ToolbarThemeOverlay</item>
     </style>
 

--- a/library/src/main/res/values/themes.xml
+++ b/library/src/main/res/values/themes.xml
@@ -1,6 +1,6 @@
 <resources>
 
-    <style name="CandyBar.Theme.Base" parent="Theme.MaterialComponents.DayNight.NoActionBar">
+    <style name="CandyBar.Theme.Base" parent="Theme.Material3.DayNight.NoActionBar">
         <item name="android:windowAnimationStyle">@null</item>
     </style>
 
@@ -32,7 +32,7 @@
         <item name="md_item_color">@color/primaryText</item>
     </style>
 
-    <style name="CandyBar.Theme.Splash" parent="Theme.MaterialComponents.DayNight">
+    <style name="CandyBar.Theme.Splash" parent="Theme.Material3.DayNight">
         <item name="windowNoTitle">true</item>
         <item name="windowActionBar">false</item>
         <item name="android:windowNoTitle">true</item>


### PR DESCRIPTION
This pr adds Material You, closes #99 
I would have prefered to add a switch but i can't really figure out how the fragments are structured😅
What this does is adding a fourth radio button in the theme picker and goes like this:
- if you're on android < 12 if you choose material you a toast appears telling you how it's only for android 12 and above and falls back to the system theme, so if dark sets to dark if light sets to light.
- if you're on android >= 12 you can set to material you following the system theme, or you can set the material you theme light if you're on dark and viceversa
Some scereenshots:
![studio64_Q03rEwFgYk](https://github.com/zixpo/candybar/assets/108683123/3eb54c0a-7b78-4fbb-88fe-0ca912883ea8)![studio64_qS3z02o6WK](https://github.com/zixpo/candybar/assets/108683123/2e062ec2-02b4-4d4c-980a-7905c2791f81)

![studio64_KKUIybKGlx](https://github.com/zixpo/candybar/assets/108683123/64943ae3-e75e-4c4a-b0a7-7a5ac2fd7fa0)

I also updated the components(only found the button and the fab)
![studio64_IfnGGtbG8g](https://github.com/zixpo/candybar/assets/108683123/a57b4ff6-e487-4e45-a5ac-127fbcb8919d)

And also updated the AGP

Thanks to @Donnnno for the help!