### PR TITLE
Add support for re-requesting icons

### DIFF
--- a/library/src/main/java/candybar/lib/adapters/RequestAdapter.java
+++ b/library/src/main/java/candybar/lib/adapters/RequestAdapter.java
@@ -211,7 +211,14 @@ public class RequestAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder
                         R.string.request_not_available));
             }
 
-            if (!mRequests.get(finalPosition).isAvailableForRequest()) {
+            if (mRequests.get(finalPosition).isRequested() && !mContext.getResources().getBoolean(R.bool.enable_icon_request_multiple)) {
+                // This icon was requested before and we do not allow multi-requests, so we
+                // keep it visually enabled in the list but disable the checkbox
+                contentViewHolder.content.setAlpha(1f);
+                contentViewHolder.title.setAlpha(1f);
+                contentViewHolder.icon.setAlpha(1f);
+                contentViewHolder.checkbox.setEnabled(false);
+            } else if (!mRequests.get(finalPosition).isAvailableForRequest()) {
                 contentViewHolder.content.setAlpha(0.5f);
                 contentViewHolder.title.setAlpha(0.5f);
                 contentViewHolder.icon.setAlpha(0.5f);
@@ -366,6 +373,11 @@ public class RequestAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder
         }
     }
 
+    public interface ToggleResultListener {
+        void onPositiveResult();
+        void onNegativeResult();
+    }
+
     private class ContentViewHolder extends RecyclerView.ViewHolder implements View.OnClickListener, View.OnLongClickListener {
 
         private final TextView title;
@@ -424,9 +436,10 @@ public class RequestAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder
             if (id == R.id.container) {
                 int position = mShowPremiumRequest || mShowRegularRequestLimit ?
                         getBindingAdapterPosition() - 1 : getBindingAdapterPosition();
-                if (toggleSelection(position)) {
-                    checkbox.toggle();
-                }
+                toggleSelection(position, new ToggleResultListener() {
+                    @Override public void onPositiveResult() { checkbox.toggle(); }
+                    @Override public void onNegativeResult() { /* Do nothing */ }
+                });
             }
         }
 
@@ -436,10 +449,11 @@ public class RequestAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder
             if (id == R.id.container) {
                 int position = mShowPremiumRequest || mShowRegularRequestLimit ?
                         getBindingAdapterPosition() - 1 : getBindingAdapterPosition();
-                if (toggleSelection(position)) {
-                    checkbox.toggle();
-                    return true;
-                }
+                toggleSelection(position, new ToggleResultListener() {
+                    @Override public void onPositiveResult() { checkbox.toggle(); }
+                    @Override public void onNegativeResult() { /* Do nothing */ }
+                });
+                return true;
             }
             return false;
         }
@@ -468,11 +482,46 @@ public class RequestAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder
         return null;
     }
 
-    private boolean toggleSelection(int position) {
+    private void toggleSelection(int position, ToggleResultListener toggleListener) {
         if (position >= 0 && position < mRequests.size()) {
-            if (mSelectedItems.get(position, false))
+            boolean isSelected = mSelectedItems.get(position, false);
+            boolean isRequested = mRequests.get(position).isRequested();
+            boolean isDuplicateRequestAllowed = mContext.getResources().getBoolean(R.bool.enable_icon_request_multiple);
+
+            if (isSelected) {
                 mSelectedItems.delete(position);
-            else if (!mRequests.get(position).isAvailableForRequest()) {
+                toggleListener.onPositiveResult();
+            } else if (isRequested) {
+                if (isDuplicateRequestAllowed) {
+                    // Icon was already requested but re-request is allowed
+                    // Ask user if they really want to re-request the icon
+                    new MaterialDialog.Builder(mContext)
+                            .typeface(TypefaceHelper.getMedium(mContext), TypefaceHelper.getRegular(mContext))
+                            .title(R.string.request_already_requested)
+                            .content(R.string.request_requested_possible)
+                            .cancelable(false)
+                            .canceledOnTouchOutside(false)
+                            .negativeText(R.string.request_requested_button_cancel)
+                            .onNegative((dialog, which) -> toggleListener.onNegativeResult())
+                            .positiveText(R.string.request_requested_button_confirm)
+                            .onPositive((dialog, which) -> {
+                                mSelectedItems.put(position, true);
+                                toggleListener.onPositiveResult();
+                            })
+                            .show();
+                } else {
+                    // Re-requesting icons is not allowed
+                    toggleListener.onNegativeResult();
+                    new MaterialDialog.Builder(mContext)
+                            .typeface(TypefaceHelper.getMedium(mContext), TypefaceHelper.getRegular(mContext))
+                            .title(R.string.request_not_available)
+                            .content(R.string.request_requested)
+                            .negativeText(R.string.request_requested_button_cancel)
+                            .show();
+                }
+            } else if (!mRequests.get(position).isAvailableForRequest()) {
+                // Icon is not available for request
+                toggleListener.onNegativeResult();
                 if (!mRequests.get(position).getInfoText().isEmpty()) {
                     new MaterialDialog.Builder(mContext)
                             .typeface(TypefaceHelper.getMedium(mContext), TypefaceHelper.getRegular(mContext))
@@ -481,18 +530,14 @@ public class RequestAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder
                             .positiveText(android.R.string.yes)
                             .show();
                 }
-                return false;
             } else {
+                // If nothing prevents us from reaching this point, we can select the icon
                 mSelectedItems.put(position, true);
+                toggleListener.onPositiveResult();
             }
-            try {
-                RequestListener listener = (RequestListener) mContext;
-                listener.onRequestSelected(getSelectedItemsSize());
-                return true;
-            } catch (Exception ignored) {
-            }
+        } else {
+            toggleListener.onNegativeResult();
         }
-        return false;
     }
 
     public boolean selectAll() {

--- a/library/src/main/java/candybar/lib/fragments/RequestFragment.java
+++ b/library/src/main/java/candybar/lib/fragments/RequestFragment.java
@@ -229,11 +229,6 @@ public class RequestFragment extends Fragment implements View.OnClickListener {
 
             int selected = mAdapter.getSelectedItemsSize();
             if (selected > 0) {
-                if (mAdapter.isContainsRequested()) {
-                    RequestHelper.showAlreadyRequestedDialog(requireActivity());
-                    return;
-                }
-
                 boolean requestLimit = getResources().getBoolean(
                         R.bool.enable_icon_request_limit);
                 boolean iconRequest = getResources().getBoolean(

--- a/library/src/main/java/candybar/lib/helpers/RequestHelper.java
+++ b/library/src/main/java/candybar/lib/helpers/RequestHelper.java
@@ -403,15 +403,6 @@ public class RequestHelper {
         return requests;
     }
 
-    public static void showAlreadyRequestedDialog(@NonNull Context context) {
-        new MaterialDialog.Builder(context)
-                .typeface(TypefaceHelper.getMedium(context), TypefaceHelper.getRegular(context))
-                .title(R.string.request_title)
-                .content(R.string.request_requested)
-                .positiveText(R.string.close)
-                .show();
-    }
-
     public static void showIconRequestLimitDialog(@NonNull Context context) {
         boolean reset = context.getResources().getBoolean(R.bool.reset_icon_request_limit);
         int limit = context.getResources().getInteger(R.integer.icon_request_limit);

--- a/library/src/main/res/values/dashboard_configurations.xml
+++ b/library/src/main/res/values/dashboard_configurations.xml
@@ -162,6 +162,12 @@
         The number of icon a user can request should be specified in the "icon_request_limit" section -->
     <bool name="enable_icon_request_limit">false</bool>
 
+    <!-- Enable multiple requests for same icon
+        When enabled, users will be able to request the same icon twice. This can be useful if you
+        offer free and premium requests, so a free request doesn't prevent the user from submitting
+        a premium request for the same icon. Can also be useful for a voting system. -->
+    <bool name="enable_icon_request_multiple">false</bool>
+
     <!-- Limit the numbers of icon a user can request
         IGNORE if "enable_icon_request_limit" option is disabled
         ex: If you set icon request limit to 10, a user will able to request only 10 icons in total

--- a/library/src/main/res/values/dashboard_strings.xml
+++ b/library/src/main/res/values/dashboard_strings.xml
@@ -209,8 +209,10 @@
     <string name="request_fetching_data">Fetching latest data …</string>
     <string name="request_build_failed">Unable to build icon request</string>
     <string name="request_appfilter_failed">Unable to read appfilter.xml</string>
-    <string name="request_requested">Please check your request again.
-        Because you are trying to request app that was already requested.</string>
+    <string name="request_requested">You already requested this icon and cannot request it again.</string>
+    <string name="request_requested_possible">You already requested this icon. Are you sure you want to spend another request on it?</string>
+    <string name="request_requested_button_cancel">Go back</string>
+    <string name="request_requested_button_confirm">Select anyway</string>
     <string name="request_email_client">Choose the app you want to use to send the icon request</string>
     <string name="request_app_disabled">You\'re using an older version of this icon pack. The requested icons may be included in the latest version. Please update your app to latest version to request icons.</string>
     <string name="connection_error_long">Unable to load data from server. Please, check your network connection.</string>


### PR DESCRIPTION
This commit changes the default behaviour and adds new behaviour hidden behind a new boolean option `enable_icon_request_multiple`.

 * When `enable_icon_request_multiple=false` (default), users cannot select icons they already requested but instead see an info dialog.

 * When `enable_icon_request_multiple=true`, users see a confirmation dialog for icons they already requested, asking them whether they are sure they want to spend another request on them.

The old default behaviour was to let the user select already requested icons but then display an error dialog when they hit the "send" button. From a user perspective it never made sense to let them select it in the first place, as the result was 100% sure to error out.

The new default behaviour happens immediately on click of the checkbox.

The new multi-request behaviour behind the flag is useful for those who want to support a voting system for free requests (i.e. let users cast multiple votes for the same icon), and useful for those with both free and premium requests (e.g. when users want to "top-up" their free requests later on to speed them up).