### PR TITLE
Add extra shortcut icon resource to pick_icon response

### DIFF
--- a/library/src/main/java/candybar/lib/helpers/IconsHelper.java
+++ b/library/src/main/java/candybar/lib/helpers/IconsHelper.java
@@ -210,6 +210,10 @@ public class IconsHelper {
                         public void handleResult(Bitmap resource) {
                             Intent intent = new Intent();
                             intent.putExtra("icon", resource);
+
+                            // Also add the direct icon resource ID to the intent for launchers that support it
+                            Intent.ShortcutIconResource iconRes = Intent.ShortcutIconResource.fromContext(context, icon.getRes());
+                            intent.putExtra(Intent.EXTRA_SHORTCUT_ICON_RESOURCE, iconRes);
                             ((AppCompatActivity) context).setResult(resource != null ?
                                     Activity.RESULT_OK : Activity.RESULT_CANCELED, intent);
                             ((AppCompatActivity) context).finish();


### PR DESCRIPTION
# Description
When "applying" an icon pack on a launcher, the launcher fetches the icons directly inside the icon pack resources, with no need to extract the icons to files first.
On Candybar, when using a PICK_ICON intent, the icon bitmap is given as the result of this intent, forcing the launcher to make some files manipulations. Moreover, if an icon is updated in the pack, this wont reflect on the launcher, which still points to the previously saves bitmap.
This PR aims at giving the launcher another way of obtaining the icon : another extra is added to the intent, which is the icon location in the resource :
- no need to save a file
- if the icon pack is using vectors, the quality will get enhanced as it will not have to get converted to png first
- icon will be automatically updated when the icon pack is updated
- usage closer to what is done when applying an icon pack
- no breaking change

Note : this way of picking icons is also what is done by Blueprint