### PR TITLE
Enable use of CandyBar as a library

### DIFF
--- a/library/src/main/java/candybar/lib/helpers/LauncherHelper.java
+++ b/library/src/main/java/candybar/lib/helpers/LauncherHelper.java
@@ -51,72 +51,57 @@ public class LauncherHelper {
                 "Action",
                 R.drawable.ic_launcher_action,
                 new String[]{"com.actionlauncher.playstore", "com.chrislacy.actionlauncher.pro"},
-                new DirectApply() {
-                    @Override
-                    public void run(Context context, String launcherPackageName) throws ActivityNotFoundException, NullPointerException {
-                        final Intent action = context.getPackageManager().getLaunchIntentForPackage(launcherPackageName);
-                        action.putExtra("apply_icon_pack", context.getPackageName());
-                        action.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-                        context.startActivity(action);
-                        ((AppCompatActivity) context).finish();
-                    }
+                (context, launcherPackageName) -> {
+                    final Intent action = context.getPackageManager().getLaunchIntentForPackage(launcherPackageName);
+                    action.putExtra("apply_icon_pack", context.getPackageName());
+                    action.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+                    context.startActivity(action);
+                    ((AppCompatActivity) context).finish();
                 }
         ),
         ADW(
                 "ADW",
                 R.drawable.ic_launcher_adw,
                 new String[]{"org.adw.launcher", "org.adwfreak.launcher"},
-                new DirectApply() {
-                    @Override
-                    public void run(Context context, String launcherPackageName) throws ActivityNotFoundException, NullPointerException {
-                        final Intent adw = new Intent("org.adw.launcher.SET_THEME");
-                        adw.putExtra("org.adw.launcher.theme.NAME", context.getPackageName());
-                        adw.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-                        context.startActivity(adw);
-                        ((AppCompatActivity) context).finish();
-                    }
+                (context, launcherPackageName) -> {
+                    final Intent adw = new Intent("org.adw.launcher.SET_THEME");
+                    adw.putExtra("org.adw.launcher.theme.NAME", context.getPackageName());
+                    adw.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+                    context.startActivity(adw);
+                    ((AppCompatActivity) context).finish();
                 }
         ),
         APEX(
                 "Apex",
                 R.drawable.ic_launcher_apex,
                 new String[]{"com.anddoes.launcher", "com.anddoes.launcher.pro"},
-                new DirectApply() {
-                    @Override
-                    public void run(Context context, String launcherPackageName) throws ActivityNotFoundException, NullPointerException {
-                        final Intent apex = new Intent("com.anddoes.launcher.SET_THEME");
-                        apex.putExtra("com.anddoes.launcher.THEME_PACKAGE_NAME", context.getPackageName());
-                        apex.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-                        context.startActivity(apex);
-                        ((AppCompatActivity) context).finish();
-                    }
+                (context, launcherPackageName) -> {
+                    final Intent apex = new Intent("com.anddoes.launcher.SET_THEME");
+                    apex.putExtra("com.anddoes.launcher.THEME_PACKAGE_NAME", context.getPackageName());
+                    apex.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+                    context.startActivity(apex);
+                    ((AppCompatActivity) context).finish();
                 }),
         BEFORE(
                 "Before",
                 R.drawable.ic_launcher_before,
                 new String[]{"com.beforesoft.launcher"},
-                new DirectApply() {
-                    @Override
-                    public void run(Context context, String launcherPackageName) throws ActivityNotFoundException, NullPointerException {
-                        final Intent before = new Intent("com.beforesoftware.launcher.APPLY_ICONS");
-                        before.putExtra("packageName", context.getPackageName());
-                        before.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-                        context.startActivity(before);
-                        ((AppCompatActivity) context).finish();
-                    }
+                (context, launcherPackageName) -> {
+                    final Intent before = new Intent("com.beforesoftware.launcher.APPLY_ICONS");
+                    before.putExtra("packageName", context.getPackageName());
+                    before.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+                    context.startActivity(before);
+                    ((AppCompatActivity) context).finish();
                 }),
         CMTHEME(
                 "CM Theme",
                 R.drawable.ic_launcher_cm,
                 new String[]{"org.cyanogenmod.theme.chooser"},
-                new DirectApply() {
-                    @Override
-                    public void run(Context context, String launcherPackageName) throws ActivityNotFoundException, NullPointerException {
-                        final Intent cmtheme = new Intent("android.intent.action.MAIN");
-                        cmtheme.setComponent(new ComponentName(launcherPackageName, "org.cyanogenmod.theme.chooser.ChooserActivity"));
-                        cmtheme.putExtra("pkgName", context.getPackageName());
-                        context.startActivity(cmtheme);
-                    }
+                (context, launcherPackageName) -> {
+                    final Intent cmtheme = new Intent("android.intent.action.MAIN");
+                    cmtheme.setComponent(new ComponentName(launcherPackageName, "org.cyanogenmod.theme.chooser.ChooserActivity"));
+                    cmtheme.putExtra("pkgName", context.getPackageName());
+                    context.startActivity(cmtheme);
                 }),
         COLOR_OS(
                 "ColorOS",
@@ -127,18 +112,15 @@ public class LauncherHelper {
                 "GO EX",
                 R.drawable.ic_launcher_go,
                 new String[]{"com.gau.go.launcherex"},
-                new DirectApply() {
-                    @Override
-                    public void run(Context context, String launcherPackageName) throws ActivityNotFoundException, NullPointerException {
-                        final Intent goex = context.getPackageManager().getLaunchIntentForPackage("com.gau.go.launcherex");
-                        final Intent go = new Intent("com.gau.go.launcherex.MyThemes.mythemeaction");
-                        go.putExtra("type", 1);
-                        go.putExtra("pkgname", context.getPackageName());
-                        goex.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-                        context.sendBroadcast(go);
-                        context.startActivity(goex);
-                        ((AppCompatActivity) context).finish();
-                    }
+                (context, launcherPackageName) -> {
+                    final Intent goex = context.getPackageManager().getLaunchIntentForPackage("com.gau.go.launcherex");
+                    final Intent go = new Intent("com.gau.go.launcherex.MyThemes.mythemeaction");
+                    go.putExtra("type", 1);
+                    go.putExtra("pkgname", context.getPackageName());
+                    goex.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+                    context.sendBroadcast(go);
+                    context.startActivity(goex);
+                    ((AppCompatActivity) context).finish();
                 }),
         HIOS(
                 "HiOS",
@@ -183,14 +165,11 @@ public class LauncherHelper {
                 "Lucid",
                 R.drawable.ic_launcher_lucid,
                 new String[]{"com.powerpoint45.launcher"},
-                new DirectApply() {
-                    @Override
-                    public void run(Context context, String launcherPackageName) throws ActivityNotFoundException, NullPointerException {
-                        final Intent lucid = new Intent("com.powerpoint45.action.APPLY_THEME", null);
-                        lucid.putExtra("icontheme", context.getPackageName());
-                        context.startActivity(lucid);
-                        ((AppCompatActivity) context).finish();
-                    }
+                (context, launcherPackageName) -> {
+                    final Intent lucid = new Intent("com.powerpoint45.action.APPLY_THEME", null);
+                    lucid.putExtra("icontheme", context.getPackageName());
+                    context.startActivity(lucid);
+                    ((AppCompatActivity) context).finish();
                 }),
         NOTHING(
                 "Nothing",
@@ -201,37 +180,31 @@ public class LauncherHelper {
                 "Nougat",
                 R.drawable.ic_launcher_nougat,
                 new String[]{"me.craftsapp.nlauncher"},
-                new DirectApply() {
-                    @Override
-                    public void run(Context context, String launcherPackageName) throws ActivityNotFoundException, NullPointerException {
-                        final Intent nougat = new Intent("me.craftsapp.nlauncher");
-                        nougat.setAction("me.craftsapp.nlauncher.SET_THEME");
-                        nougat.putExtra("me.craftsapp.nlauncher.theme.NAME", context.getPackageName());
-                        nougat.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-                        context.startActivity(nougat);
-                        ((AppCompatActivity) context).finish();
-                    }
+                (context, launcherPackageName) -> {
+                    final Intent nougat = new Intent("me.craftsapp.nlauncher");
+                    nougat.setAction("me.craftsapp.nlauncher.SET_THEME");
+                    nougat.putExtra("me.craftsapp.nlauncher.theme.NAME", context.getPackageName());
+                    nougat.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+                    context.startActivity(nougat);
+                    ((AppCompatActivity) context).finish();
                 }),
         NOVA(
                 "Nova",
                 R.drawable.ic_launcher_nova,
                 new String[]{"com.teslacoilsw.launcher", "com.teslacoilsw.launcher.prime"},
-                new DirectApply() {
-                    @Override
-                    public void run(Context context, String launcherPackageName) throws ActivityNotFoundException, NullPointerException {
-                        final Intent nova = new Intent("com.teslacoilsw.launcher.APPLY_ICON_THEME");
-                        nova.setPackage("com.teslacoilsw.launcher");
-                        nova.putExtra("com.teslacoilsw.launcher.extra.ICON_THEME_TYPE", "GO");
-                        nova.putExtra("com.teslacoilsw.launcher.extra.ICON_THEME_PACKAGE", context.getPackageName());
-                        String reshapeSetting = context.getResources().getString(R.string.nova_reshape_legacy_icons);
-                        if (!reshapeSetting.equals("KEEP")) {
-                            // Allowed values are ON, OFF and AUTO
-                            nova.putExtra("com.teslacoilsw.launcher.extra.ICON_THEME_RESHAPE", reshapeSetting);
-                        }
-                        nova.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-                        context.startActivity(nova);
-                        ((AppCompatActivity) context).finish();
+                (context, launcherPackageName) -> {
+                    final Intent nova = new Intent("com.teslacoilsw.launcher.APPLY_ICON_THEME");
+                    nova.setPackage("com.teslacoilsw.launcher");
+                    nova.putExtra("com.teslacoilsw.launcher.extra.ICON_THEME_TYPE", "GO");
+                    nova.putExtra("com.teslacoilsw.launcher.extra.ICON_THEME_PACKAGE", context.getPackageName());
+                    String reshapeSetting = context.getResources().getString(R.string.nova_reshape_legacy_icons);
+                    if (!reshapeSetting.equals("KEEP")) {
+                        // Allowed values are ON, OFF and AUTO
+                        nova.putExtra("com.teslacoilsw.launcher.extra.ICON_THEME_RESHAPE", reshapeSetting);
                     }
+                    nova.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+                    context.startActivity(nova);
+                    ((AppCompatActivity) context).finish();
                 }),
         OXYGEN_OS(
                 "OxygenOS",
@@ -247,47 +220,38 @@ public class LauncherHelper {
                 "Projectivy",
                 R.drawable.ic_launcher_projectivy,
                 new String[]{"com.spocky.projengmenu"},
-                new DirectApply() {
-                    @Override
-                    public void run(Context context, String launcherPackageName) throws ActivityNotFoundException, NullPointerException {
-                        final Intent projectivy = new Intent("com.spocky.projengmenu.APPLY_ICONPACK");
-                        projectivy.setPackage("com.spocky.projengmenu");
-                        projectivy.putExtra("com.spocky.projengmenu.extra.ICONPACK_PACKAGENAME", context.getPackageName());
-                        projectivy.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-                        context.startActivity(projectivy);
-                        ((AppCompatActivity) context).finish();
-                    }
+                (context, launcherPackageName) -> {
+                    final Intent projectivy = new Intent("com.spocky.projengmenu.APPLY_ICONPACK");
+                    projectivy.setPackage("com.spocky.projengmenu");
+                    projectivy.putExtra("com.spocky.projengmenu.extra.ICONPACK_PACKAGENAME", context.getPackageName());
+                    projectivy.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+                    context.startActivity(projectivy);
+                    ((AppCompatActivity) context).finish();
                 }),
         SMART(
                 "Smart",
                 R.drawable.ic_launcher_smart,
                 new String[]{"ginlemon.flowerfree", "ginlemon.flowerpro", "ginlemon.flowerpro.special"},
-                new DirectApply() {
-                    @Override
-                    public void run(Context context, String launcherPackageName) throws ActivityNotFoundException, NullPointerException {
-                        final Intent smart = new Intent("ginlemon.smartlauncher.setGSLTHEME");
-                        smart.putExtra("package", context.getPackageName());
-                        smart.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-                        context.startActivity(smart);
-                        ((AppCompatActivity) context).finish();
-                    }
+                (context, launcherPackageName) -> {
+                    final Intent smart = new Intent("ginlemon.smartlauncher.setGSLTHEME");
+                    smart.putExtra("package", context.getPackageName());
+                    smart.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+                    context.startActivity(smart);
+                    ((AppCompatActivity) context).finish();
                 }),
         SOLO(
                 "Solo",
                 R.drawable.ic_launcher_solo,
                 new String[]{"home.solo.launcher.free"},
-                new DirectApply() {
-                    @Override
-                    public void run(Context context, String launcherPackageName) throws ActivityNotFoundException, NullPointerException {
-                        final Intent solo = context.getPackageManager().getLaunchIntentForPackage("home.solo.launcher.free");
-                        final Intent soloAction = new Intent("home.solo.launcher.free.APPLY_THEME");
-                        soloAction.putExtra("EXTRA_THEMENAME", context.getResources().getString(R.string.app_name));
-                        soloAction.putExtra("EXTRA_PACKAGENAME", context.getPackageName());
-                        solo.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-                        context.sendBroadcast(soloAction);
-                        context.startActivity(solo);
-                        ((AppCompatActivity) context).finish();
-                    }
+                (context, launcherPackageName) -> {
+                    final Intent solo = context.getPackageManager().getLaunchIntentForPackage("home.solo.launcher.free");
+                    final Intent soloAction = new Intent("home.solo.launcher.free.APPLY_THEME");
+                    soloAction.putExtra("EXTRA_THEMENAME", context.getResources().getString(R.string.app_name));
+                    soloAction.putExtra("EXTRA_PACKAGENAME", context.getPackageName());
+                    solo.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+                    context.sendBroadcast(soloAction);
+                    context.startActivity(solo);
+                    ((AppCompatActivity) context).finish();
                 }),
         STOCK_LEGACY(
                 /*
@@ -323,45 +287,36 @@ public class LauncherHelper {
                 "Flick",
                 R.drawable.ic_launcher_flick,
                 new String[]{"com.universallauncher.universallauncher"},
-                new DirectApply() {
-                    @Override
-                    public void run(Context context, String launcherPackageName) throws ActivityNotFoundException, NullPointerException {
-                        final Intent flick = context.getPackageManager().getLaunchIntentForPackage("com.universallauncher.universallauncher");
-                        final Intent flickAction = new Intent("com.universallauncher.universallauncher.FLICK_ICON_PACK_APPLIER");
-                        flickAction.putExtra("com.universallauncher.universallauncher.ICON_THEME_PACKAGE", context.getPackageName());
-                        flickAction.setComponent(new ComponentName("com.universallauncher.universallauncher", "com.android.launcher3.icon.ApplyIconPack"));
-                        flick.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-                        context.sendBroadcast(flickAction);
-                        context.startActivity(flick);
-                        ((AppCompatActivity) context).finish();
-                    }
+                (context, launcherPackageName) -> {
+                    final Intent flick = context.getPackageManager().getLaunchIntentForPackage("com.universallauncher.universallauncher");
+                    final Intent flickAction = new Intent("com.universallauncher.universallauncher.FLICK_ICON_PACK_APPLIER");
+                    flickAction.putExtra("com.universallauncher.universallauncher.ICON_THEME_PACKAGE", context.getPackageName());
+                    flickAction.setComponent(new ComponentName("com.universallauncher.universallauncher", "com.android.launcher3.icon.ApplyIconPack"));
+                    flick.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+                    context.sendBroadcast(flickAction);
+                    context.startActivity(flick);
+                    ((AppCompatActivity) context).finish();
                 }),
         SQUARE(
                 "Square",
                 R.drawable.ic_launcher_square,
                 new String[]{"com.ss.squarehome2"},
-                new DirectApply() {
-                    @Override
-                    public void run(Context context, String launcherPackageName) throws ActivityNotFoundException, NullPointerException {
-                        final Intent square = new Intent("com.ss.squarehome2.ACTION_APPLY_ICONPACK");
-                        square.setComponent(ComponentName.unflattenFromString("com.ss.squarehome2/.ApplyThemeActivity"));
-                        square.putExtra("com.ss.squarehome2.EXTRA_ICONPACK", context.getPackageName());
-                        context.startActivity(square);
-                        // FIXME: We never call ((AppCompatActivity) context).finish(); here, is that intentional?
-                    }
+                (context, launcherPackageName) -> {
+                    final Intent square = new Intent("com.ss.squarehome2.ACTION_APPLY_ICONPACK");
+                    square.setComponent(ComponentName.unflattenFromString("com.ss.squarehome2/.ApplyThemeActivity"));
+                    square.putExtra("com.ss.squarehome2.EXTRA_ICONPACK", context.getPackageName());
+                    context.startActivity(square);
+                    // FIXME: We never call ((AppCompatActivity) context).finish(); here, is that intentional?
                 }),
         NIAGARA(
                 "Niagara",
                 R.drawable.ic_launcher_niagara,
                 new String[]{"bitpit.launcher"},
-                new DirectApply() {
-                    @Override
-                    public void run(Context context, String launcherPackageName) throws ActivityNotFoundException, NullPointerException {
-                        final Intent niagara = new Intent("bitpit.launcher.APPLY_ICONS");
-                        niagara.putExtra("packageName", context.getPackageName());
-                        context.startActivity(niagara);
-                        // FIXME: We never call ((AppCompatActivity) context).finish(); here, is that intentional?
-                    }
+                (context, launcherPackageName) -> {
+                    final Intent niagara = new Intent("bitpit.launcher.APPLY_ICONS");
+                    niagara.putExtra("packageName", context.getPackageName());
+                    context.startActivity(niagara);
+                    // FIXME: We never call ((AppCompatActivity) context).finish(); here, is that intentional?
                 }),
         HYPERION(
                 "Hyperion",
@@ -392,17 +347,14 @@ public class LauncherHelper {
                 "ZenUI",
                 R.drawable.ic_launcher_zenui,
                 new String[]{"com.asus.launcher"},
-                new DirectApply() {
-                    @Override
-                    public void run(Context context, String launcherPackageName) throws ActivityNotFoundException, NullPointerException {
-                        final Intent asus = new Intent("com.asus.launcher");
-                        asus.setAction("com.asus.launcher.intent.action.APPLY_ICONPACK");
-                        asus.addCategory(Intent.CATEGORY_DEFAULT);
-                        asus.putExtra("com.asus.launcher.iconpack.PACKAGE_NAME", context.getPackageName());
-                        asus.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-                        context.startActivity(asus);
-                        ((AppCompatActivity) context).finish();
-                    }
+                (context, launcherPackageName) -> {
+                    final Intent asus = new Intent("com.asus.launcher");
+                    asus.setAction("com.asus.launcher.intent.action.APPLY_ICONPACK");
+                    asus.addCategory(Intent.CATEGORY_DEFAULT);
+                    asus.putExtra("com.asus.launcher.iconpack.PACKAGE_NAME", context.getPackageName());
+                    asus.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+                    context.startActivity(asus);
+                    ((AppCompatActivity) context).finish();
                 });
 
         /**

--- a/library/src/main/java/candybar/lib/helpers/LauncherHelper.java
+++ b/library/src/main/java/candybar/lib/helpers/LauncherHelper.java
@@ -44,6 +44,9 @@ public class LauncherHelper {
 
     private static final String thirdPartyHelperURL = "https://play.google.com/store/apps/details?id=rk.android.app.shortcutmaker";
 
+    private static final Launcher.DirectApply DIRECT_APPLY_NOT_SUPPORTED = null;
+    private static final Launcher.ManualApply MANUAL_APPLY_NOT_SUPPORTED = null;
+
     public enum Launcher {
         UNKNOWN,
 
@@ -54,7 +57,7 @@ public class LauncherHelper {
                 (context, launcherPackageName) -> context.getPackageManager().getLaunchIntentForPackage(launcherPackageName)
                     .putExtra("apply_icon_pack", context.getPackageName())
                     .setFlags(Intent.FLAG_ACTIVITY_NEW_TASK),
-                null
+                MANUAL_APPLY_NOT_SUPPORTED
         ),
         ADW(
                 "ADW",
@@ -63,7 +66,7 @@ public class LauncherHelper {
                 (context, launcherPackageName) -> new Intent("org.adw.launcher.SET_THEME")
                         .putExtra("org.adw.launcher.theme.NAME", context.getPackageName())
                         .setFlags(Intent.FLAG_ACTIVITY_NEW_TASK),
-                null
+                MANUAL_APPLY_NOT_SUPPORTED
         ),
         APEX(
                 "Apex",
@@ -72,7 +75,7 @@ public class LauncherHelper {
                 (context, launcherPackageName) -> new Intent("com.anddoes.launcher.SET_THEME")
                         .putExtra("com.anddoes.launcher.THEME_PACKAGE_NAME", context.getPackageName())
                         .setFlags(Intent.FLAG_ACTIVITY_NEW_TASK),
-                null
+                MANUAL_APPLY_NOT_SUPPORTED
         ),
         BEFORE(
                 "Before",
@@ -81,7 +84,7 @@ public class LauncherHelper {
                 (context, launcherPackageName) -> new Intent("com.beforesoftware.launcher.APPLY_ICONS")
                         .putExtra("packageName", context.getPackageName())
                         .setFlags(Intent.FLAG_ACTIVITY_NEW_TASK),
-                null
+                MANUAL_APPLY_NOT_SUPPORTED
         ),
         CMTHEME(
                 "CM Theme",
@@ -90,7 +93,7 @@ public class LauncherHelper {
                 (context, launcherPackageName) -> new Intent("android.intent.action.MAIN")
                     .setComponent(new ComponentName(launcherPackageName, "org.cyanogenmod.theme.chooser.ChooserActivity"))
                     .putExtra("pkgName", context.getPackageName()),
-                null
+                MANUAL_APPLY_NOT_SUPPORTED
         ),
         COLOR_OS(
                 "ColorOS",
@@ -114,7 +117,7 @@ public class LauncherHelper {
                                 .putExtra("pkgname", context.getPackageName());
                     }
                 },
-                null
+                MANUAL_APPLY_NOT_SUPPORTED
         ),
         HIOS(
                 "HiOS",
@@ -145,7 +148,7 @@ public class LauncherHelper {
                                 .putExtra("packageName", context.getPackageName());
                     }
                 },
-                null
+                MANUAL_APPLY_NOT_SUPPORTED
         ),
         LGHOME(
                 "LG Home",
@@ -157,7 +160,7 @@ public class LauncherHelper {
                 new String[]{"com.powerpoint45.launcher"},
                 (context, launcherPackageName) -> new Intent("com.powerpoint45.action.APPLY_THEME", null)
                         .putExtra("icontheme", context.getPackageName()),
-                null
+                MANUAL_APPLY_NOT_SUPPORTED
         ),
         NOTHING(
                 "Nothing",
@@ -171,7 +174,7 @@ public class LauncherHelper {
                     .setAction("me.craftsapp.nlauncher.SET_THEME")
                     .putExtra("me.craftsapp.nlauncher.theme.NAME", context.getPackageName())
                     .setFlags(Intent.FLAG_ACTIVITY_NEW_TASK),
-                null
+                MANUAL_APPLY_NOT_SUPPORTED
         ),
         NOVA(
                 "Nova",
@@ -190,7 +193,7 @@ public class LauncherHelper {
                     nova.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
                     return nova;
                 },
-                null
+                MANUAL_APPLY_NOT_SUPPORTED
         ),
         OXYGEN_OS(
                 "OxygenOS",
@@ -208,7 +211,7 @@ public class LauncherHelper {
                         .setPackage("com.spocky.projengmenu")
                         .putExtra("com.spocky.projengmenu.extra.ICONPACK_PACKAGENAME", context.getPackageName())
                         .setFlags(Intent.FLAG_ACTIVITY_NEW_TASK),
-                null
+                MANUAL_APPLY_NOT_SUPPORTED
         ),
         SMART(
                 "Smart",
@@ -217,7 +220,7 @@ public class LauncherHelper {
                 (context, launcherPackageName) -> new Intent("ginlemon.smartlauncher.setGSLTHEME")
                         .putExtra("package", context.getPackageName())
                         .setFlags(Intent.FLAG_ACTIVITY_NEW_TASK),
-                null
+                MANUAL_APPLY_NOT_SUPPORTED
         ),
         SOLO(
                 "Solo",
@@ -237,7 +240,7 @@ public class LauncherHelper {
                                 .putExtra("EXTRA_PACKAGENAME", context.getPackageName());
                     }
                 },
-                null
+                MANUAL_APPLY_NOT_SUPPORTED
         ),
         STOCK_LEGACY(
                 /*
@@ -280,7 +283,7 @@ public class LauncherHelper {
                                 .putExtra("com.universallauncher.universallauncher.ICON_THEME_PACKAGE", context.getPackageName())
                                 .setComponent(new ComponentName("com.universallauncher.universallauncher", "com.android.launcher3.icon.ApplyIconPack"));
                     }
-                }, null
+                }, MANUAL_APPLY_NOT_SUPPORTED
         ),
         SQUARE(
                 "Square",
@@ -289,7 +292,7 @@ public class LauncherHelper {
                 (context, launcherPackageName) -> new Intent("com.ss.squarehome2.ACTION_APPLY_ICONPACK")
                         .setComponent(ComponentName.unflattenFromString("com.ss.squarehome2/.ApplyThemeActivity"))
                         .putExtra("com.ss.squarehome2.EXTRA_ICONPACK", context.getPackageName()),
-                null
+                MANUAL_APPLY_NOT_SUPPORTED
         ),
         NIAGARA(
                 "Niagara",
@@ -297,7 +300,7 @@ public class LauncherHelper {
                 new String[]{"bitpit.launcher"},
                 (context, launcherPackageName) -> new Intent("bitpit.launcher.APPLY_ICONS")
                         .putExtra("packageName", context.getPackageName()),
-                null
+                MANUAL_APPLY_NOT_SUPPORTED
         ),
         HYPERION(
                 "Hyperion",
@@ -328,7 +331,7 @@ public class LauncherHelper {
                         .addCategory(Intent.CATEGORY_DEFAULT)
                         .putExtra("com.asus.launcher.iconpack.PACKAGE_NAME", context.getPackageName())
                         .setFlags(Intent.FLAG_ACTIVITY_NEW_TASK),
-                null
+                MANUAL_APPLY_NOT_SUPPORTED
         );
 
         /**

--- a/library/src/main/java/candybar/lib/helpers/LauncherHelper.java
+++ b/library/src/main/java/candybar/lib/helpers/LauncherHelper.java
@@ -330,7 +330,16 @@ public class LauncherHelper {
                 "Square",
                 R.drawable.ic_launcher_square,
                 new String[]{"com.ss.squarehome2"},
-                true),
+                new DirectApply() {
+                    @Override
+                    public void run(Context context, String packageName) throws ActivityNotFoundException, NullPointerException {
+                        final Intent square = new Intent("com.ss.squarehome2.ACTION_APPLY_ICONPACK");
+                        square.setComponent(ComponentName.unflattenFromString("com.ss.squarehome2/.ApplyThemeActivity"));
+                        square.putExtra("com.ss.squarehome2.EXTRA_ICONPACK", context.getPackageName());
+                        context.startActivity(square);
+                        // FIXME: We never call ((AppCompatActivity) context).finish(); here, is that intentional?
+                    }
+                }),
         NIAGARA(
                 "Niagara",
                 R.drawable.ic_launcher_niagara,
@@ -781,15 +790,7 @@ public class LauncherHelper {
                 launcher.applyDirectly(context, launcherPackage, true);
                 break;
             case SQUARE:
-                try {
-                    final Intent square = new Intent("com.ss.squarehome2.ACTION_APPLY_ICONPACK");
-                    square.setComponent(ComponentName.unflattenFromString("com.ss.squarehome2/.ApplyThemeActivity"));
-                    square.putExtra("com.ss.squarehome2.EXTRA_ICONPACK", context.getPackageName());
-                    context.startActivity(square);
-                    logLauncherDirectApply(launcherPackage);
-                } catch (ActivityNotFoundException | NullPointerException e) {
-                    openGooglePlay(context, launcherPackage, launcherName);
-                }
+                launcher.applyDirectly(context, launcherPackage, true);
                 break;
             case STOCK_LEGACY:
                 applyWithInstructions(

--- a/library/src/main/java/candybar/lib/helpers/LauncherHelper.java
+++ b/library/src/main/java/candybar/lib/helpers/LauncherHelper.java
@@ -517,10 +517,18 @@ public class LauncherHelper {
          * not a guarantee, so make sure to catch the exceptions thrown by this method and handle
          * them gracefully.
          *
-         * <p><b>Credit where credit is due</b></p>
-         * <p>The activities, intents, logic and fallbacks behind this simple method are the
-         * collective work of dozens of open source developers carried out over many years. If you
-         * use this method outside of the CandyBar app, please credit the contributors.</p>
+         * <p>
+         *  <sup>
+         *      <b>Credit where credit is due ♥</b><br>
+         *
+         *     The instructions, logic and fallback behind this simple method are the
+         *     collective work of dozens of open source developers and translators carried
+         *     out over many years. If you use this method outside of the CandyBar dashboard,
+         *     please credit the contributors.<br>
+         *     • <b>Contributors:</b> com/candybar/lib/src/main/res/xml/dashboard_contributors.xml<br>
+         *     • <b>Translators:</b> com/candybar/lib/src/main/res/xml/dashboard_translator.xml
+         *  </sup>
+         * </p>
          *
          * @param launcherPackageName The package name of the launcher to apply the icon pack to.
          * @throws LauncherNotInstalledException If the launcher isn't installed on the device.
@@ -546,6 +554,7 @@ public class LauncherHelper {
          * rather handle exceptions yourself, use `applyDirectly` without the boolean parameter
          * and catch exceptions `LauncherNotInstalledException`, `LauncherDirectApplyFailed` and
          * `LauncherDirectApplyNotSupported`.
+         *
          * @param launcherPackageName The package name of the launcher to apply the icon pack to.
          * @param openGooglePlayUponError If true, open Google Play if the launcher isn't installed.
          */
@@ -561,6 +570,31 @@ public class LauncherHelper {
             }
         }
 
+        /**
+         * Show manual instructions to the user on how to apply the icon pack to the launcher. In
+         * case the launcher offers a dedicated settings activity, it will be called after the user
+         * confirms the dialog. (If the user cancels the dialog, nothing happens.)
+         *
+         * <p>
+         *  <sup>
+         *      <b>Credit where credit is due ♥</b><br>
+         *
+         *     The instructions, logic and fallback behind this simple method are the
+         *     collective work of dozens of open source developers and translators carried
+         *     out over many years. If you use this method outside of the CandyBar dashboard,
+         *     please credit the contributors.<br>
+         *     • <b>Contributors:</b> com/candybar/lib/src/main/res/xml/dashboard_contributors.xml<br>
+         *     • <b>Translators:</b> com/candybar/lib/src/main/res/xml/dashboard_translator.xml
+         *  </sup>
+         * </p>
+         *
+         * @param launcherPackageName The package name of the launcher to apply the icon pack to.
+         * @param launcherName The name of the launcher to display in the dialog.
+         * @throws LauncherNotInstalledException If the launcher isn't installed on the device.
+         * @throws LauncherManualApplyNotSupported If the launcher doesn't support applying icon packs manually.
+         * @throws LauncherManualApplyFailed If an associated settings activity could not be launched. This is never an expected case. If it happens, it might indicate that the launcher interface changed.
+         *
+         */
         public void applyManually(Context context, String launcherPackageName, String launcherName) throws ActivityNotFoundException, NullPointerException {
             if (!isInstalled(context, launcherPackageName)) throw new LauncherNotInstalledException(new ActivityNotFoundException());
             if (manualApplyFunc == null) throw new LauncherManualApplyNotSupported(new ActivityNotFoundException());

--- a/library/src/main/java/candybar/lib/helpers/LauncherHelper.java
+++ b/library/src/main/java/candybar/lib/helpers/LauncherHelper.java
@@ -51,58 +51,47 @@ public class LauncherHelper {
                 "Action",
                 R.drawable.ic_launcher_action,
                 new String[]{"com.actionlauncher.playstore", "com.chrislacy.actionlauncher.pro"},
-                (context, launcherPackageName) -> {
-                    final Intent action = context.getPackageManager().getLaunchIntentForPackage(launcherPackageName);
-                    action.putExtra("apply_icon_pack", context.getPackageName());
-                    action.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-                    context.startActivity(action);
-                    ((AppCompatActivity) context).finish();
-                }
+                (context, launcherPackageName) -> context.getPackageManager().getLaunchIntentForPackage(launcherPackageName)
+                    .putExtra("apply_icon_pack", context.getPackageName())
+                    .setFlags(Intent.FLAG_ACTIVITY_NEW_TASK),
+                null
         ),
         ADW(
                 "ADW",
                 R.drawable.ic_launcher_adw,
                 new String[]{"org.adw.launcher", "org.adwfreak.launcher"},
-                (context, launcherPackageName) -> {
-                    final Intent adw = new Intent("org.adw.launcher.SET_THEME");
-                    adw.putExtra("org.adw.launcher.theme.NAME", context.getPackageName());
-                    adw.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-                    context.startActivity(adw);
-                    ((AppCompatActivity) context).finish();
-                }
+                (context, launcherPackageName) -> new Intent("org.adw.launcher.SET_THEME")
+                        .putExtra("org.adw.launcher.theme.NAME", context.getPackageName())
+                        .setFlags(Intent.FLAG_ACTIVITY_NEW_TASK),
+                null
         ),
         APEX(
                 "Apex",
                 R.drawable.ic_launcher_apex,
                 new String[]{"com.anddoes.launcher", "com.anddoes.launcher.pro"},
-                (context, launcherPackageName) -> {
-                    final Intent apex = new Intent("com.anddoes.launcher.SET_THEME");
-                    apex.putExtra("com.anddoes.launcher.THEME_PACKAGE_NAME", context.getPackageName());
-                    apex.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-                    context.startActivity(apex);
-                    ((AppCompatActivity) context).finish();
-                }),
+                (context, launcherPackageName) -> new Intent("com.anddoes.launcher.SET_THEME")
+                        .putExtra("com.anddoes.launcher.THEME_PACKAGE_NAME", context.getPackageName())
+                        .setFlags(Intent.FLAG_ACTIVITY_NEW_TASK),
+                null
+        ),
         BEFORE(
                 "Before",
                 R.drawable.ic_launcher_before,
                 new String[]{"com.beforesoft.launcher"},
-                (context, launcherPackageName) -> {
-                    final Intent before = new Intent("com.beforesoftware.launcher.APPLY_ICONS");
-                    before.putExtra("packageName", context.getPackageName());
-                    before.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-                    context.startActivity(before);
-                    ((AppCompatActivity) context).finish();
-                }),
+                (context, launcherPackageName) -> new Intent("com.beforesoftware.launcher.APPLY_ICONS")
+                        .putExtra("packageName", context.getPackageName())
+                        .setFlags(Intent.FLAG_ACTIVITY_NEW_TASK),
+                null
+        ),
         CMTHEME(
                 "CM Theme",
                 R.drawable.ic_launcher_cm,
                 new String[]{"org.cyanogenmod.theme.chooser"},
-                (context, launcherPackageName) -> {
-                    final Intent cmtheme = new Intent("android.intent.action.MAIN");
-                    cmtheme.setComponent(new ComponentName(launcherPackageName, "org.cyanogenmod.theme.chooser.ChooserActivity"));
-                    cmtheme.putExtra("pkgName", context.getPackageName());
-                    context.startActivity(cmtheme);
-                }),
+                (context, launcherPackageName) -> new Intent("android.intent.action.MAIN")
+                    .setComponent(new ComponentName(launcherPackageName, "org.cyanogenmod.theme.chooser.ChooserActivity"))
+                    .putExtra("pkgName", context.getPackageName()),
+                null
+        ),
         COLOR_OS(
                 "ColorOS",
                 R.drawable.ic_launcher_color_os,
@@ -111,16 +100,22 @@ public class LauncherHelper {
                 "GO EX",
                 R.drawable.ic_launcher_go,
                 new String[]{"com.gau.go.launcherex"},
-                (context, launcherPackageName) -> {
-                    final Intent goex = context.getPackageManager().getLaunchIntentForPackage("com.gau.go.launcherex");
-                    final Intent go = new Intent("com.gau.go.launcherex.MyThemes.mythemeaction");
-                    go.putExtra("type", 1);
-                    go.putExtra("pkgname", context.getPackageName());
-                    goex.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-                    context.sendBroadcast(go);
-                    context.startActivity(goex);
-                    ((AppCompatActivity) context).finish();
-                }),
+                new DirectApply() {
+                    @Override
+                    public Intent getActivity(Context context, String launcherPackageName) {
+                        return context.getPackageManager().getLaunchIntentForPackage("com.gau.go.launcherex")
+                                .setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+                    }
+
+                    @Override
+                    public Intent getBroadcast(Context context) {
+                        return new Intent("com.gau.go.launcherex.MyThemes.mythemeaction")
+                                .putExtra("type", 1)
+                                .putExtra("pkgname", context.getPackageName());
+                    }
+                },
+                null
+        ),
         HIOS(
                 "HiOS",
                 R.drawable.ic_launcher_hios,
@@ -145,13 +140,13 @@ public class LauncherHelper {
                     }
 
                     @Override
-                    public void run(Context context, String launcherPackageName) throws ActivityNotFoundException, NullPointerException {
-                        final Intent lawnchair = new Intent("ch.deletescape.lawnchair.APPLY_ICONS", null);
-                        lawnchair.putExtra("packageName", context.getPackageName());
-                        context.startActivity(lawnchair);
-                        ((AppCompatActivity) context).finish();
+                    public Intent getActivity(Context context, String launcherName) {
+                        return new Intent("ch.deletescape.lawnchair.APPLY_ICONS", null)
+                                .putExtra("packageName", context.getPackageName());
                     }
-                }),
+                },
+                null
+        ),
         LGHOME(
                 "LG Home",
                 R.drawable.ic_launcher_lg,
@@ -160,12 +155,10 @@ public class LauncherHelper {
                 "Lucid",
                 R.drawable.ic_launcher_lucid,
                 new String[]{"com.powerpoint45.launcher"},
-                (context, launcherPackageName) -> {
-                    final Intent lucid = new Intent("com.powerpoint45.action.APPLY_THEME", null);
-                    lucid.putExtra("icontheme", context.getPackageName());
-                    context.startActivity(lucid);
-                    ((AppCompatActivity) context).finish();
-                }),
+                (context, launcherPackageName) -> new Intent("com.powerpoint45.action.APPLY_THEME", null)
+                        .putExtra("icontheme", context.getPackageName()),
+                null
+        ),
         NOTHING(
                 "Nothing",
                 R.drawable.ic_launcher_nothing,
@@ -174,14 +167,12 @@ public class LauncherHelper {
                 "Nougat",
                 R.drawable.ic_launcher_nougat,
                 new String[]{"me.craftsapp.nlauncher"},
-                (context, launcherPackageName) -> {
-                    final Intent nougat = new Intent("me.craftsapp.nlauncher");
-                    nougat.setAction("me.craftsapp.nlauncher.SET_THEME");
-                    nougat.putExtra("me.craftsapp.nlauncher.theme.NAME", context.getPackageName());
-                    nougat.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-                    context.startActivity(nougat);
-                    ((AppCompatActivity) context).finish();
-                }),
+                (context, launcherPackageName) -> new Intent("me.craftsapp.nlauncher")
+                    .setAction("me.craftsapp.nlauncher.SET_THEME")
+                    .putExtra("me.craftsapp.nlauncher.theme.NAME", context.getPackageName())
+                    .setFlags(Intent.FLAG_ACTIVITY_NEW_TASK),
+                null
+        ),
         NOVA(
                 "Nova",
                 R.drawable.ic_launcher_nova,
@@ -197,9 +188,10 @@ public class LauncherHelper {
                         nova.putExtra("com.teslacoilsw.launcher.extra.ICON_THEME_RESHAPE", reshapeSetting);
                     }
                     nova.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-                    context.startActivity(nova);
-                    ((AppCompatActivity) context).finish();
-                }),
+                    return nova;
+                },
+                null
+        ),
         OXYGEN_OS(
                 "OxygenOS",
                 R.drawable.ic_launcher_oxygen_os,
@@ -212,39 +204,41 @@ public class LauncherHelper {
                 "Projectivy",
                 R.drawable.ic_launcher_projectivy,
                 new String[]{"com.spocky.projengmenu"},
-                (context, launcherPackageName) -> {
-                    final Intent projectivy = new Intent("com.spocky.projengmenu.APPLY_ICONPACK");
-                    projectivy.setPackage("com.spocky.projengmenu");
-                    projectivy.putExtra("com.spocky.projengmenu.extra.ICONPACK_PACKAGENAME", context.getPackageName());
-                    projectivy.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-                    context.startActivity(projectivy);
-                    ((AppCompatActivity) context).finish();
-                }),
+                (context, launcherPackageName) -> new Intent("com.spocky.projengmenu.APPLY_ICONPACK")
+                        .setPackage("com.spocky.projengmenu")
+                        .putExtra("com.spocky.projengmenu.extra.ICONPACK_PACKAGENAME", context.getPackageName())
+                        .setFlags(Intent.FLAG_ACTIVITY_NEW_TASK),
+                null
+        ),
         SMART(
                 "Smart",
                 R.drawable.ic_launcher_smart,
                 new String[]{"ginlemon.flowerfree", "ginlemon.flowerpro", "ginlemon.flowerpro.special"},
-                (context, launcherPackageName) -> {
-                    final Intent smart = new Intent("ginlemon.smartlauncher.setGSLTHEME");
-                    smart.putExtra("package", context.getPackageName());
-                    smart.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-                    context.startActivity(smart);
-                    ((AppCompatActivity) context).finish();
-                }),
+                (context, launcherPackageName) -> new Intent("ginlemon.smartlauncher.setGSLTHEME")
+                        .putExtra("package", context.getPackageName())
+                        .setFlags(Intent.FLAG_ACTIVITY_NEW_TASK),
+                null
+        ),
         SOLO(
                 "Solo",
                 R.drawable.ic_launcher_solo,
                 new String[]{"home.solo.launcher.free"},
-                (context, launcherPackageName) -> {
-                    final Intent solo = context.getPackageManager().getLaunchIntentForPackage("home.solo.launcher.free");
-                    final Intent soloAction = new Intent("home.solo.launcher.free.APPLY_THEME");
-                    soloAction.putExtra("EXTRA_THEMENAME", context.getResources().getString(R.string.app_name));
-                    soloAction.putExtra("EXTRA_PACKAGENAME", context.getPackageName());
-                    solo.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-                    context.sendBroadcast(soloAction);
-                    context.startActivity(solo);
-                    ((AppCompatActivity) context).finish();
-                }),
+                new DirectApply() {
+                    @Override
+                    public Intent getActivity(Context context, String launcherPackageName) {
+                        return context.getPackageManager().getLaunchIntentForPackage("home.solo.launcher.free")
+                                .setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+                    }
+
+                    @Override
+                    public Intent getBroadcast(Context context) {
+                        return new Intent("home.solo.launcher.free.APPLY_THEME")
+                                .putExtra("EXTRA_THEMENAME", context.getResources().getString(R.string.app_name))
+                                .putExtra("EXTRA_PACKAGENAME", context.getPackageName());
+                    }
+                },
+                null
+        ),
         STOCK_LEGACY(
                 /*
                  * Historically, ColorOS, OxygenOS and realme UI were standalone launcher variants
@@ -274,37 +268,37 @@ public class LauncherHelper {
                 "Flick",
                 R.drawable.ic_launcher_flick,
                 new String[]{"com.universallauncher.universallauncher"},
-                (context, launcherPackageName) -> {
-                    final Intent flick = context.getPackageManager().getLaunchIntentForPackage("com.universallauncher.universallauncher");
-                    final Intent flickAction = new Intent("com.universallauncher.universallauncher.FLICK_ICON_PACK_APPLIER");
-                    flickAction.putExtra("com.universallauncher.universallauncher.ICON_THEME_PACKAGE", context.getPackageName());
-                    flickAction.setComponent(new ComponentName("com.universallauncher.universallauncher", "com.android.launcher3.icon.ApplyIconPack"));
-                    flick.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-                    context.sendBroadcast(flickAction);
-                    context.startActivity(flick);
-                    ((AppCompatActivity) context).finish();
-                }),
+                new DirectApply() {
+                    @Override
+                    public Intent getActivity(Context context, String launcherPackageName) {
+                        return context.getPackageManager().getLaunchIntentForPackage("com.universallauncher.universallauncher")
+                                .setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+                    }
+                    @Override
+                    public Intent getBroadcast(Context context) {
+                        return new Intent("com.universallauncher.universallauncher.FLICK_ICON_PACK_APPLIER")
+                                .putExtra("com.universallauncher.universallauncher.ICON_THEME_PACKAGE", context.getPackageName())
+                                .setComponent(new ComponentName("com.universallauncher.universallauncher", "com.android.launcher3.icon.ApplyIconPack"));
+                    }
+                }, null
+        ),
         SQUARE(
                 "Square",
                 R.drawable.ic_launcher_square,
                 new String[]{"com.ss.squarehome2"},
-                (context, launcherPackageName) -> {
-                    final Intent square = new Intent("com.ss.squarehome2.ACTION_APPLY_ICONPACK");
-                    square.setComponent(ComponentName.unflattenFromString("com.ss.squarehome2/.ApplyThemeActivity"));
-                    square.putExtra("com.ss.squarehome2.EXTRA_ICONPACK", context.getPackageName());
-                    context.startActivity(square);
-                    // FIXME: We never call ((AppCompatActivity) context).finish(); here, is that intentional?
-                }),
+                (context, launcherPackageName) -> new Intent("com.ss.squarehome2.ACTION_APPLY_ICONPACK")
+                        .setComponent(ComponentName.unflattenFromString("com.ss.squarehome2/.ApplyThemeActivity"))
+                        .putExtra("com.ss.squarehome2.EXTRA_ICONPACK", context.getPackageName()),
+                null
+        ),
         NIAGARA(
                 "Niagara",
                 R.drawable.ic_launcher_niagara,
                 new String[]{"bitpit.launcher"},
-                (context, launcherPackageName) -> {
-                    final Intent niagara = new Intent("bitpit.launcher.APPLY_ICONS");
-                    niagara.putExtra("packageName", context.getPackageName());
-                    context.startActivity(niagara);
-                    // FIXME: We never call ((AppCompatActivity) context).finish(); here, is that intentional?
-                }),
+                (context, launcherPackageName) -> new Intent("bitpit.launcher.APPLY_ICONS")
+                        .putExtra("packageName", context.getPackageName()),
+                null
+        ),
         HYPERION(
                 "Hyperion",
                 R.drawable.ic_launcher_hyperion,
@@ -329,15 +323,13 @@ public class LauncherHelper {
                 "ZenUI",
                 R.drawable.ic_launcher_zenui,
                 new String[]{"com.asus.launcher"},
-                (context, launcherPackageName) -> {
-                    final Intent asus = new Intent("com.asus.launcher");
-                    asus.setAction("com.asus.launcher.intent.action.APPLY_ICONPACK");
-                    asus.addCategory(Intent.CATEGORY_DEFAULT);
-                    asus.putExtra("com.asus.launcher.iconpack.PACKAGE_NAME", context.getPackageName());
-                    asus.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-                    context.startActivity(asus);
-                    ((AppCompatActivity) context).finish();
-                });
+                (context, launcherPackageName) -> new Intent("com.asus.launcher")
+                        .setAction("com.asus.launcher.intent.action.APPLY_ICONPACK")
+                        .addCategory(Intent.CATEGORY_DEFAULT)
+                        .putExtra("com.asus.launcher.iconpack.PACKAGE_NAME", context.getPackageName())
+                        .setFlags(Intent.FLAG_ACTIVITY_NEW_TASK),
+                null
+        );
 
         /**
          * Interface for launchers to implement when they support applying icons directly, without

--- a/library/src/main/java/candybar/lib/helpers/LauncherHelper.java
+++ b/library/src/main/java/candybar/lib/helpers/LauncherHelper.java
@@ -201,7 +201,17 @@ public class LauncherHelper {
                 "Nougat",
                 R.drawable.ic_launcher_nougat,
                 new String[]{"me.craftsapp.nlauncher"},
-                true),
+                new DirectApply() {
+                    @Override
+                    public void run(Context context, String packageName) throws ActivityNotFoundException, NullPointerException {
+                        final Intent nougat = new Intent("me.craftsapp.nlauncher");
+                        nougat.setAction("me.craftsapp.nlauncher.SET_THEME");
+                        nougat.putExtra("me.craftsapp.nlauncher.theme.NAME", context.getPackageName());
+                        nougat.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+                        context.startActivity(nougat);
+                        ((AppCompatActivity) context).finish();
+                    }
+                }),
         NOVA(
                 "Nova",
                 R.drawable.ic_launcher_nova,
@@ -813,23 +823,7 @@ public class LauncherHelper {
                 );
                 break;
             case NOUGAT:
-                try {
-                    /*
-                     * Just want to let anyone who is going to copy
-                     * It's not easy searching for this
-                     * I will be grateful if you take this with a proper credit
-                     * Thank you
-                     */
-                    final Intent nougat = new Intent("me.craftsapp.nlauncher");
-                    nougat.setAction("me.craftsapp.nlauncher.SET_THEME");
-                    nougat.putExtra("me.craftsapp.nlauncher.theme.NAME", context.getPackageName());
-                    nougat.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-                    context.startActivity(nougat);
-                    ((AppCompatActivity) context).finish();
-                    logLauncherDirectApply(launcherPackage);
-                } catch (ActivityNotFoundException | NullPointerException e) {
-                    openGooglePlay(context, launcherPackage, launcherName);
-                }
+                launcher.applyDirectly(context, launcherPackage, true);
                 break;
             case ZENUI:
                 try {

--- a/library/src/main/java/candybar/lib/helpers/LauncherHelper.java
+++ b/library/src/main/java/candybar/lib/helpers/LauncherHelper.java
@@ -237,7 +237,17 @@ public class LauncherHelper {
                 "Projectivy",
                 R.drawable.ic_launcher_projectivy,
                 new String[]{"com.spocky.projengmenu"},
-                true),
+                new DirectApply() {
+                    @Override
+                    public void run(Context context, String packageName) throws ActivityNotFoundException, NullPointerException {
+                        final Intent projectivy = new Intent("com.spocky.projengmenu.APPLY_ICONPACK");
+                        projectivy.setPackage("com.spocky.projengmenu");
+                        projectivy.putExtra("com.spocky.projengmenu.extra.ICONPACK_PACKAGENAME", context.getPackageName());
+                        projectivy.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+                        context.startActivity(projectivy);
+                        ((AppCompatActivity) context).finish();
+                    }
+                }),
         SMART(
                 "Smart",
                 R.drawable.ic_launcher_smart,
@@ -732,17 +742,7 @@ public class LauncherHelper {
                 applyManual(context, launcherPackage, launcherName, "com.miui.home.settings.HomeSettingsActivity");
                 break;
             case PROJECTIVY:
-                try {
-                    final Intent projectivy = new Intent("com.spocky.projengmenu.APPLY_ICONPACK");
-                    projectivy.setPackage("com.spocky.projengmenu");
-                    projectivy.putExtra("com.spocky.projengmenu.extra.ICONPACK_PACKAGENAME", context.getPackageName());
-                    projectivy.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-                    context.startActivity(projectivy);
-                    ((AppCompatActivity) context).finish();
-                    logLauncherDirectApply(launcherPackage);
-                } catch (ActivityNotFoundException | NullPointerException e) {
-                    openGooglePlay(context, launcherPackage, launcherName);
-                }
+                launcher.applyDirectly(context, launcherPackage, true);
                 break;
             case ONEUI:
                 applyOneUI(context, launcherName);

--- a/library/src/main/java/candybar/lib/helpers/LauncherHelper.java
+++ b/library/src/main/java/candybar/lib/helpers/LauncherHelper.java
@@ -392,7 +392,18 @@ public class LauncherHelper {
                 "ZenUI",
                 R.drawable.ic_launcher_zenui,
                 new String[]{"com.asus.launcher"},
-                true);
+                new DirectApply() {
+                    @Override
+                    public void run(Context context, String packageName) throws ActivityNotFoundException, NullPointerException {
+                        final Intent asus = new Intent("com.asus.launcher");
+                        asus.setAction("com.asus.launcher.intent.action.APPLY_ICONPACK");
+                        asus.addCategory(Intent.CATEGORY_DEFAULT);
+                        asus.putExtra("com.asus.launcher.iconpack.PACKAGE_NAME", context.getPackageName());
+                        asus.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+                        context.startActivity(asus);
+                        ((AppCompatActivity) context).finish();
+                    }
+                });
 
         private interface DirectApply {
             default boolean isSupported(String packageName) {return true;}
@@ -826,18 +837,7 @@ public class LauncherHelper {
                 launcher.applyDirectly(context, launcherPackage, true);
                 break;
             case ZENUI:
-                try {
-                    final Intent asus = new Intent("com.asus.launcher");
-                    asus.setAction("com.asus.launcher.intent.action.APPLY_ICONPACK");
-                    asus.addCategory(Intent.CATEGORY_DEFAULT);
-                    asus.putExtra("com.asus.launcher.iconpack.PACKAGE_NAME", context.getPackageName());
-                    asus.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-                    context.startActivity(asus);
-                    ((AppCompatActivity) context).finish();
-                    logLauncherDirectApply(launcherPackage);
-                } catch (ActivityNotFoundException | NullPointerException e) {
-                    openGooglePlay(context, launcherPackage, launcherName);
-                }
+                launcher.applyDirectly(context, launcherPackage, true);
                 break;
         }
     }

--- a/library/src/main/java/candybar/lib/helpers/LauncherHelper.java
+++ b/library/src/main/java/candybar/lib/helpers/LauncherHelper.java
@@ -106,8 +106,7 @@ public class LauncherHelper {
         COLOR_OS(
                 "ColorOS",
                 R.drawable.ic_launcher_color_os,
-                new String[]{"com.oppo.launcher"},
-                false),
+                new String[]{"com.oppo.launcher"}),
         GO(
                 "GO EX",
                 R.drawable.ic_launcher_go,
@@ -125,18 +124,15 @@ public class LauncherHelper {
         HIOS(
                 "HiOS",
                 R.drawable.ic_launcher_hios,
-                new String[]{"com.transsion.hilauncher"},
-                false),
+                new String[]{"com.transsion.hilauncher"}),
         HOLO(
                 "Holo",
                 R.drawable.ic_launcher_holo,
-                new String[]{"com.mobint.hololauncher"},
-                false),
+                new String[]{"com.mobint.hololauncher"}),
         HOLOHD(
                 "Holo HD",
                 R.drawable.ic_launcher_holohd,
-                new String[]{"com.mobint.hololauncher.hd"},
-                false),
+                new String[]{"com.mobint.hololauncher.hd"}),
         LAWNCHAIR(
                 "Lawnchair",
                 R.drawable.ic_launcher_lawnchair,
@@ -159,8 +155,7 @@ public class LauncherHelper {
         LGHOME(
                 "LG Home",
                 R.drawable.ic_launcher_lg,
-                new String[]{"com.lge.launcher2", "com.lge.launcher3"},
-                false),
+                new String[]{"com.lge.launcher2", "com.lge.launcher3"}),
         LUCID(
                 "Lucid",
                 R.drawable.ic_launcher_lucid,
@@ -174,8 +169,7 @@ public class LauncherHelper {
         NOTHING(
                 "Nothing",
                 R.drawable.ic_launcher_nothing,
-                new String[]{"com.nothing.launcher"},
-                false),
+                new String[]{"com.nothing.launcher"}),
         NOUGAT(
                 "Nougat",
                 R.drawable.ic_launcher_nougat,
@@ -209,13 +203,11 @@ public class LauncherHelper {
         OXYGEN_OS(
                 "OxygenOS",
                 R.drawable.ic_launcher_oxygen_os,
-                new String[]{"net.oneplus.launcher"},
-                false),
+                new String[]{"net.oneplus.launcher"}),
         PIXEL(
                 "Pixel",
                 R.drawable.ic_launcher_pixel,
-                new String[]{"com.google.android.apps.nexuslauncher"},
-                false),
+                new String[]{"com.google.android.apps.nexuslauncher"}),
         PROJECTIVY(
                 "Projectivy",
                 R.drawable.ic_launcher_projectivy,
@@ -261,28 +253,23 @@ public class LauncherHelper {
                  */
                 isColorOS() ? "ColorOS" : isRealmeUI() ? "realme UI" : "Stock Launcher",
                 isColorOS() ? R.drawable.ic_launcher_color_os : isRealmeUI() ? R.drawable.ic_launcher_realme_ui : R.drawable.ic_launcher_android,
-                new String[]{"com.android.launcher"},
-                false),
+                new String[]{"com.android.launcher"}),
         POCO(
                 "POCO",
                 R.drawable.ic_launcher_poco,
-                new String[]{"com.mi.android.globallauncher"},
-                false),
+                new String[]{"com.mi.android.globallauncher"}),
         MOTO(
                 "Moto Launcher",
                 R.drawable.ic_launcher_moto,
-                new String[]{"com.motorola.launcher3"},
-                false),
+                new String[]{"com.motorola.launcher3"}),
         MICROSOFT(
                 "Microsoft",
                 R.drawable.ic_launcher_microsoft,
-                new String[]{"com.microsoft.launcher"},
-                false),
+                new String[]{"com.microsoft.launcher"}),
         BLACKBERRY(
                 "BlackBerry",
                 R.drawable.ic_launcher_blackberry,
-                new String[]{"com.blackberry.blackberrylauncher"},
-                false),
+                new String[]{"com.blackberry.blackberrylauncher"}),
         FLICK(
                 "Flick",
                 R.drawable.ic_launcher_flick,
@@ -321,28 +308,23 @@ public class LauncherHelper {
         HYPERION(
                 "Hyperion",
                 R.drawable.ic_launcher_hyperion,
-                new String[]{"projekt.launcher"},
-                false),
+                new String[]{"projekt.launcher"}),
         KISS(
                 "KISS",
                 R.drawable.ic_launcher_kiss,
-                new String[]{"fr.neamar.kiss"},
-                false),
+                new String[]{"fr.neamar.kiss"}),
         Kvaesitso(
                 "Kvaesitso",
                 R.drawable.ic_launcher_kvaesitso,
-                new String[]{"de.mm20.launcher2.release"},
-                false),
+                new String[]{"de.mm20.launcher2.release"}),
         ONEUI(
                 "Samsung One UI",
                 R.drawable.ic_launcher_one_ui,
-                new String[]{"com.sec.android.app.launcher"},
-                false),
+                new String[]{"com.sec.android.app.launcher"}),
         TINYBIT(
                 "TinyBit",
                 R.drawable.ic_launcher_tinybit,
-                new String[]{"rocks.tbog.tblauncher"},
-                false),
+                new String[]{"rocks.tbog.tblauncher"}),
         ZENUI(
                 "ZenUI",
                 R.drawable.ic_launcher_zenui,
@@ -359,27 +341,39 @@ public class LauncherHelper {
 
         /**
          * Interface for launchers to implement when they support applying icons directly, without
-         * the need to open the icon pack app. The {%code run()} method should be self-contained
+         * the need to open the icon pack app. The {@code run()} method should be self-contained
          * and make sure to finish the activity after applying the icon pack.
          */
         private interface DirectApply {
-            default boolean isSupported(String packageName) {return true;}
+            default boolean isSupported(String packageName) { return true; }
 
-            void run(Context context, String launcherPackageName) throws ActivityNotFoundException, NullPointerException;
+            Intent getActivity(Context context, String launcherPackageName);
+            default Intent getBroadcast(Context context) { return null; }
+
+            default void run(Context context, String launcherPackageName) throws ActivityNotFoundException, NullPointerException {
+                final Intent activity = getActivity(context, launcherPackageName);
+                final Intent broadcast = getBroadcast(context);
+                if (getBroadcast(context) != null) {
+                    context.sendBroadcast(broadcast);
+                }
+                context.startActivity(activity);
+                ((AppCompatActivity) context).finish();
+            }
         }
 
         /**
          * Interface for launchers to implement when they support icon packs but not direct apply.
          * They should provide an overall compatibility description and a list of instructions for
-         * users to follow step by step on their device.
+         * users to follow step by step on their device. The {@code run()} method should be
+         * self-contained and either launch a deep link into the launcher's settings where the icon
+         * pack can be applied, or simply display a dialog with the instructions.
+         *
+         * @see Launcher#applyWithInstructions(Context, String, String, String[])
          */
         private interface ManualApply {
-            /**
-             * The resource ID of the compatibility description string for the launcher. Unless you
-             * have some launcher-specific things to say, you can use the default implementation
-             * which returns a generic description message that works for any launcher.
-             */
-            default String description(Context context, String launcherName) {
+            default boolean isSupported(String packageName) { return true; }
+
+            default String getCompatibilityMessage(Context context, String launcherName) {
                 return context.getResources().getString(
                         R.string.apply_manual,
                         launcherName,
@@ -387,19 +381,16 @@ public class LauncherHelper {
                 );
             }
 
-            /**
-             * A list of resource IDs for the instructions to apply the icon pack manually.
-             * The order of steps in the list matches the order of steps the user will be
-             * presented. Make them concise and easy to follow.
-             *
-             * <p>Example definition:</p>
-             * <pre>{@code
-             * new String[] {
-             *    context.getResources().getString(R.string.apply_manual_step_1), // "Long-tap home screen"
-             *    context.getResources().getString(R.string.apply_manual_step_2), // "Pick %s from the list"
-             * }</pre>
-             */
-            String[] instructionSteps(Context context);
+            String[] getInstructionSteps(Context context, String launcherName);
+
+            default void run(Context context, String launcherPackageName, String launcherName) throws ActivityNotFoundException, NullPointerException {
+                applyWithInstructions(
+                        context,
+                        launcherName,
+                        getCompatibilityMessage(context, launcherName),
+                        getInstructionSteps(context, launcherName)
+                );
+            }
         }
 
         /**
@@ -433,6 +424,12 @@ public class LauncherHelper {
             }
         }
 
+        public static class LauncherManualApplyNotSupported extends ActivityNotFoundException {
+            public LauncherManualApplyNotSupported(Throwable cause) {
+                super("The launcher does not support manual apply");
+                initCause(cause); // preserves the original exceptions information
+            }
+        }
         /**
          * Exception thrown when the icon pack couldn't be applied to the launcher directly. Catch
          * this when you want to show a user-friendly message to the user or offer the user to send
@@ -449,11 +446,26 @@ public class LauncherHelper {
             }
         }
 
+        /**
+         * Exception thrown when the launcher's activity couldn't be run. Catch this when you want
+         * to show a user-friendly message to the user or offer the user to send a bug report. In
+         * the wild, this exception could indicate that the launcher has been updated by the
+         * developers and its activity names have changed.
+         * For cases when the launcher isn't installed, use `LauncherNotInstalledException`.
+         *
+         * @see LauncherNotInstalledException
+         */
+        public static class LauncherManualApplyFailed extends ActivityNotFoundException {
+            public LauncherManualApplyFailed(Throwable cause) {
+                super("The launcher supports manual apply but launching the activity failed");
+                initCause(cause); // preserves the original exceptions information
+            }
+        }
+
         public final String name;
         public final @DrawableRes
         int icon;
         public final String[] packages;
-        private final boolean directApply;
         private DirectApply directApplyFunc = null;
         private ManualApply manualApplyFunc = null;
 
@@ -461,39 +473,20 @@ public class LauncherHelper {
             this.name = null;
             this.icon = 0;
             this.packages = null;
-            this.directApply = false;
         }
 
-        Launcher(String name, @DrawableRes int icon, String[] packages, boolean directApply) {
+        Launcher(String name, @DrawableRes int icon, String[] packages) {
             this.name = name;
             this.icon = icon;
             this.packages = packages;
-            this.directApply = directApply;
-        }
-
-        Launcher(String name, @DrawableRes int icon, String[] packages, ManualApply manualApplyFunc) {
-            this.name = name;
-            this.icon = icon;
-            this.packages = packages;
-            this.directApply = false;
-            this.manualApplyFunc = manualApplyFunc;
         }
 
         Launcher(String name, @DrawableRes int icon, String[] packages, DirectApply directApplyFunc, ManualApply manualApplyFunc) {
             this.name = name;
             this.icon = icon;
             this.packages = packages;
-            this.directApply = true;
             this.directApplyFunc = directApplyFunc;
             this.manualApplyFunc = manualApplyFunc;
-        }
-
-        Launcher(String name, @DrawableRes int icon, String[] packages, DirectApply directApplyFunc) {
-            this.name = name;
-            this.icon = icon;
-            this.packages = packages;
-            this.directApply = true;
-            this.directApplyFunc = directApplyFunc;
         }
 
         /**
@@ -510,7 +503,20 @@ public class LauncherHelper {
             if (directApplyFunc != null) {
                 return directApplyFunc.isSupported(launcherPackageName);
             }
-            return directApply;
+            return false;
+        }
+
+        /**
+         * Check if the launcher supports applying icon packs manually. Not all launchers do,
+         * specifically not those that want to stay close to Vanilla Android.
+         * @param launcherPackageName The package name of the launcher to check
+         * @return true if the launcher supports manual apply, false otherwise
+         */
+        public boolean supportsManualApply(String launcherPackageName) {
+            if (manualApplyFunc != null) {
+                return manualApplyFunc.isSupported(launcherPackageName);
+            }
+            return false;
         }
 
         /**
@@ -533,7 +539,7 @@ public class LauncherHelper {
          */
         public void applyDirectly(Context context, String launcherPackageName) throws ActivityNotFoundException, NullPointerException {
             if (!isInstalled(context, launcherPackageName)) throw new LauncherNotInstalledException(new ActivityNotFoundException());
-            if (!directApply || directApplyFunc == null) throw new LauncherDirectApplyNotSupported(new ActivityNotFoundException());
+            if (directApplyFunc == null) throw new LauncherDirectApplyNotSupported(new ActivityNotFoundException());
             try {
                 directApplyFunc.run(context, launcherPackageName);
                 logLauncherDirectApply(launcherPackageName);
@@ -563,14 +569,15 @@ public class LauncherHelper {
             }
         }
 
-        public void applyManually(Context context, String launcherName, boolean openGooglePlayUponError) {
-            if (manualApplyFunc != null) {
-                applyWithInstructions(
-                        context,
-                        this.name,
-                        this.manualApplyFunc.description(context, launcherName),
-                        this.manualApplyFunc.instructionSteps(context)
-                );
+        public void applyManually(Context context, String launcherPackageName, String launcherName) throws ActivityNotFoundException, NullPointerException {
+            if (!isInstalled(context, launcherPackageName)) throw new LauncherNotInstalledException(new ActivityNotFoundException());
+            if (manualApplyFunc == null) throw new LauncherManualApplyNotSupported(new ActivityNotFoundException());
+
+            try {
+                manualApplyFunc.run(context, launcherPackageName, launcherName);
+                //logLauncherManualApply(launcherPackageName);
+            } catch (Exception e) {
+                throw new LauncherManualApplyFailed(e);
             }
         }
     }
@@ -646,7 +653,7 @@ public class LauncherHelper {
                 }
                 break;
             case BLACKBERRY:
-                applyManual(context, launcherPackage, launcherName, "com.blackberry.blackberrylauncher.MainActivity");
+                applyManualInApp(context, launcherPackage, launcherName, "com.blackberry.blackberrylauncher.MainActivity");
                 break;
             case CMTHEME:
                 try {
@@ -744,10 +751,10 @@ public class LauncherHelper {
                 break;
             case HOLO:
             case HOLOHD:
-                applyManual(context, launcherPackage, launcherName, "com.mobint.hololauncher.SettingsActivity");
+                applyManualInApp(context, launcherPackage, launcherName, "com.mobint.hololauncher.SettingsActivity");
                 break;
             case HYPERION:
-                applyManual(context, launcherPackage, launcherName, "projekt.launcher.activities.SettingsActivity");
+                applyManualInApp(context, launcherPackage, launcherName, "projekt.launcher.activities.SettingsActivity");
                 break;
             case KISS:
                 applyWithInstructions(
@@ -786,7 +793,7 @@ public class LauncherHelper {
                 if (launcher.supportsDirectApply(launcherPackage)) {
                     launcher.applyDirectly(context, launcherPackage, true);
                 } else {
-                    applyManual(context, launcherPackage, launcherName, "app.lawnchair.ui.preferences.PreferenceActivity");
+                    applyManualInApp(context, launcherPackage, launcherName, "app.lawnchair.ui.preferences.PreferenceActivity");
                 }
                 break;
             case LGHOME:
@@ -796,7 +803,7 @@ public class LauncherHelper {
                 launcher.applyDirectly(context, launcherPackage, true);
                 break;
             case MICROSOFT:
-                applyManual(context, launcherPackage, launcherName, null);
+                applyManualInApp(context, launcherPackage, launcherName, null);
                 break;
             case NIAGARA:
                 launcher.applyDirectly(context, launcherPackage, true);
@@ -828,7 +835,7 @@ public class LauncherHelper {
                 launcherIncompatible(context, launcherName);
                 break;
             case POCO:
-                applyManual(context, launcherPackage, launcherName, "com.miui.home.settings.HomeSettingsActivity");
+                applyManualInApp(context, launcherPackage, launcherName, "com.miui.home.settings.HomeSettingsActivity");
                 break;
             case PROJECTIVY:
                 launcher.applyDirectly(context, launcherPackage, true);
@@ -837,10 +844,10 @@ public class LauncherHelper {
                 applyOneUI(context, launcherName);
                 break;
             case TINYBIT:
-                applyManual(context, launcherPackage, launcherName, "rocks.tbog.tblauncher.SettingsActivity");
+                applyManualInApp(context, launcherPackage, launcherName, "rocks.tbog.tblauncher.SettingsActivity");
                 break;
             case MOTO:
-                applyManual(context, launcherPackage, launcherName, "com.motorola.personalize.app.IconPacksActivity");
+                applyManualInApp(context, launcherPackage, launcherName, "com.motorola.personalize.app.IconPacksActivity");
                 break;
             case SMART:
                 launcher.applyDirectly(context, launcherPackage, true);
@@ -881,7 +888,7 @@ public class LauncherHelper {
     }
 
     @SuppressLint("StringFormatInvalid")
-    private static void applyManual(Context context, String launcherPackage, String launcherName, String activity) {
+    private static void applyManualInApp(Context context, String launcherPackage, String launcherName, String activity) {
         if (isInstalled(context, launcherPackage)) {
             new MaterialDialog.Builder(context)
                     .typeface(TypefaceHelper.getMedium(context), TypefaceHelper.getRegular(context))
@@ -947,8 +954,8 @@ public class LauncherHelper {
         new MaterialDialog.Builder(context)
                 .typeface(TypefaceHelper.getMedium(context), TypefaceHelper.getRegular(context))
                 .title(launcherName)
-                .content(description + "\n\n\t• " + String.join("\n\t• ", steps))
-                .positiveText(android.R.string.yes)
+                .content(description + ((steps.length > 0) ? "\n\n\t• " : "") + String.join("\n\t• ", steps))
+                .positiveText(android.R.string.ok)
                 .onPositive((dialog, which) -> {
                     CandyBarApplication.getConfiguration().getAnalyticsHandler().logEvent(
                             "click",

--- a/library/src/main/java/candybar/lib/helpers/LauncherHelper.java
+++ b/library/src/main/java/candybar/lib/helpers/LauncherHelper.java
@@ -252,7 +252,16 @@ public class LauncherHelper {
                 "Smart",
                 R.drawable.ic_launcher_smart,
                 new String[]{"ginlemon.flowerfree", "ginlemon.flowerpro", "ginlemon.flowerpro.special"},
-                true),
+                new DirectApply() {
+                    @Override
+                    public void run(Context context, String packageName) throws ActivityNotFoundException, NullPointerException {
+                        final Intent smart = new Intent("ginlemon.smartlauncher.setGSLTHEME");
+                        smart.putExtra("package", context.getPackageName());
+                        smart.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+                        context.startActivity(smart);
+                        ((AppCompatActivity) context).finish();
+                    }
+                }),
         SOLO(
                 "Solo",
                 R.drawable.ic_launcher_solo,
@@ -754,16 +763,7 @@ public class LauncherHelper {
                 applyManual(context, launcherPackage, launcherName, "com.motorola.personalize.app.IconPacksActivity");
                 break;
             case SMART:
-                try {
-                    final Intent smart = new Intent("ginlemon.smartlauncher.setGSLTHEME");
-                    smart.putExtra("package", context.getPackageName());
-                    smart.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-                    context.startActivity(smart);
-                    ((AppCompatActivity) context).finish();
-                    logLauncherDirectApply(launcherPackage);
-                } catch (ActivityNotFoundException | NullPointerException e) {
-                    openGooglePlay(context, launcherPackage, launcherName);
-                }
+                launcher.applyDirectly(context, launcherPackage, true);
                 break;
             case SOLO:
                 try {

--- a/library/src/main/java/candybar/lib/helpers/LauncherHelper.java
+++ b/library/src/main/java/candybar/lib/helpers/LauncherHelper.java
@@ -53,8 +53,8 @@ public class LauncherHelper {
                 new String[]{"com.actionlauncher.playstore", "com.chrislacy.actionlauncher.pro"},
                 new DirectApply() {
                     @Override
-                    public void run(Context context, String packageName) throws ActivityNotFoundException, NullPointerException {
-                        final Intent action = context.getPackageManager().getLaunchIntentForPackage(packageName);
+                    public void run(Context context, String launcherPackageName) throws ActivityNotFoundException, NullPointerException {
+                        final Intent action = context.getPackageManager().getLaunchIntentForPackage(launcherPackageName);
                         action.putExtra("apply_icon_pack", context.getPackageName());
                         action.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
                         context.startActivity(action);
@@ -68,7 +68,7 @@ public class LauncherHelper {
                 new String[]{"org.adw.launcher", "org.adwfreak.launcher"},
                 new DirectApply() {
                     @Override
-                    public void run(Context context, String packageName) throws ActivityNotFoundException, NullPointerException {
+                    public void run(Context context, String launcherPackageName) throws ActivityNotFoundException, NullPointerException {
                         final Intent adw = new Intent("org.adw.launcher.SET_THEME");
                         adw.putExtra("org.adw.launcher.theme.NAME", context.getPackageName());
                         adw.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
@@ -83,7 +83,7 @@ public class LauncherHelper {
                 new String[]{"com.anddoes.launcher", "com.anddoes.launcher.pro"},
                 new DirectApply() {
                     @Override
-                    public void run(Context context, String packageName) throws ActivityNotFoundException, NullPointerException {
+                    public void run(Context context, String launcherPackageName) throws ActivityNotFoundException, NullPointerException {
                         final Intent apex = new Intent("com.anddoes.launcher.SET_THEME");
                         apex.putExtra("com.anddoes.launcher.THEME_PACKAGE_NAME", context.getPackageName());
                         apex.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
@@ -97,7 +97,7 @@ public class LauncherHelper {
                 new String[]{"com.beforesoft.launcher"},
                 new DirectApply() {
                     @Override
-                    public void run(Context context, String packageName) throws ActivityNotFoundException, NullPointerException {
+                    public void run(Context context, String launcherPackageName) throws ActivityNotFoundException, NullPointerException {
                         final Intent before = new Intent("com.beforesoftware.launcher.APPLY_ICONS");
                         before.putExtra("packageName", context.getPackageName());
                         before.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
@@ -111,9 +111,9 @@ public class LauncherHelper {
                 new String[]{"org.cyanogenmod.theme.chooser"},
                 new DirectApply() {
                     @Override
-                    public void run(Context context, String packageName) throws ActivityNotFoundException, NullPointerException {
+                    public void run(Context context, String launcherPackageName) throws ActivityNotFoundException, NullPointerException {
                         final Intent cmtheme = new Intent("android.intent.action.MAIN");
-                        cmtheme.setComponent(new ComponentName(packageName, "org.cyanogenmod.theme.chooser.ChooserActivity"));
+                        cmtheme.setComponent(new ComponentName(launcherPackageName, "org.cyanogenmod.theme.chooser.ChooserActivity"));
                         cmtheme.putExtra("pkgName", context.getPackageName());
                         context.startActivity(cmtheme);
                     }
@@ -129,7 +129,7 @@ public class LauncherHelper {
                 new String[]{"com.gau.go.launcherex"},
                 new DirectApply() {
                     @Override
-                    public void run(Context context, String packageName) throws ActivityNotFoundException, NullPointerException {
+                    public void run(Context context, String launcherPackageName) throws ActivityNotFoundException, NullPointerException {
                         final Intent goex = context.getPackageManager().getLaunchIntentForPackage("com.gau.go.launcherex");
                         final Intent go = new Intent("com.gau.go.launcherex.MyThemes.mythemeaction");
                         go.putExtra("type", 1);
@@ -167,7 +167,7 @@ public class LauncherHelper {
                     }
 
                     @Override
-                    public void run(Context context, String packageName) throws ActivityNotFoundException, NullPointerException {
+                    public void run(Context context, String launcherPackageName) throws ActivityNotFoundException, NullPointerException {
                         final Intent lawnchair = new Intent("ch.deletescape.lawnchair.APPLY_ICONS", null);
                         lawnchair.putExtra("packageName", context.getPackageName());
                         context.startActivity(lawnchair);
@@ -185,7 +185,7 @@ public class LauncherHelper {
                 new String[]{"com.powerpoint45.launcher"},
                 new DirectApply() {
                     @Override
-                    public void run(Context context, String packageName) throws ActivityNotFoundException, NullPointerException {
+                    public void run(Context context, String launcherPackageName) throws ActivityNotFoundException, NullPointerException {
                         final Intent lucid = new Intent("com.powerpoint45.action.APPLY_THEME", null);
                         lucid.putExtra("icontheme", context.getPackageName());
                         context.startActivity(lucid);
@@ -203,7 +203,7 @@ public class LauncherHelper {
                 new String[]{"me.craftsapp.nlauncher"},
                 new DirectApply() {
                     @Override
-                    public void run(Context context, String packageName) throws ActivityNotFoundException, NullPointerException {
+                    public void run(Context context, String launcherPackageName) throws ActivityNotFoundException, NullPointerException {
                         final Intent nougat = new Intent("me.craftsapp.nlauncher");
                         nougat.setAction("me.craftsapp.nlauncher.SET_THEME");
                         nougat.putExtra("me.craftsapp.nlauncher.theme.NAME", context.getPackageName());
@@ -218,7 +218,7 @@ public class LauncherHelper {
                 new String[]{"com.teslacoilsw.launcher", "com.teslacoilsw.launcher.prime"},
                 new DirectApply() {
                     @Override
-                    public void run(Context context, String packageName) throws ActivityNotFoundException, NullPointerException {
+                    public void run(Context context, String launcherPackageName) throws ActivityNotFoundException, NullPointerException {
                         final Intent nova = new Intent("com.teslacoilsw.launcher.APPLY_ICON_THEME");
                         nova.setPackage("com.teslacoilsw.launcher");
                         nova.putExtra("com.teslacoilsw.launcher.extra.ICON_THEME_TYPE", "GO");
@@ -249,7 +249,7 @@ public class LauncherHelper {
                 new String[]{"com.spocky.projengmenu"},
                 new DirectApply() {
                     @Override
-                    public void run(Context context, String packageName) throws ActivityNotFoundException, NullPointerException {
+                    public void run(Context context, String launcherPackageName) throws ActivityNotFoundException, NullPointerException {
                         final Intent projectivy = new Intent("com.spocky.projengmenu.APPLY_ICONPACK");
                         projectivy.setPackage("com.spocky.projengmenu");
                         projectivy.putExtra("com.spocky.projengmenu.extra.ICONPACK_PACKAGENAME", context.getPackageName());
@@ -264,7 +264,7 @@ public class LauncherHelper {
                 new String[]{"ginlemon.flowerfree", "ginlemon.flowerpro", "ginlemon.flowerpro.special"},
                 new DirectApply() {
                     @Override
-                    public void run(Context context, String packageName) throws ActivityNotFoundException, NullPointerException {
+                    public void run(Context context, String launcherPackageName) throws ActivityNotFoundException, NullPointerException {
                         final Intent smart = new Intent("ginlemon.smartlauncher.setGSLTHEME");
                         smart.putExtra("package", context.getPackageName());
                         smart.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
@@ -278,7 +278,7 @@ public class LauncherHelper {
                 new String[]{"home.solo.launcher.free"},
                 new DirectApply() {
                     @Override
-                    public void run(Context context, String packageName) throws ActivityNotFoundException, NullPointerException {
+                    public void run(Context context, String launcherPackageName) throws ActivityNotFoundException, NullPointerException {
                         final Intent solo = context.getPackageManager().getLaunchIntentForPackage("home.solo.launcher.free");
                         final Intent soloAction = new Intent("home.solo.launcher.free.APPLY_THEME");
                         soloAction.putExtra("EXTRA_THEMENAME", context.getResources().getString(R.string.app_name));
@@ -325,7 +325,7 @@ public class LauncherHelper {
                 new String[]{"com.universallauncher.universallauncher"},
                 new DirectApply() {
                     @Override
-                    public void run(Context context, String packageName) throws ActivityNotFoundException, NullPointerException {
+                    public void run(Context context, String launcherPackageName) throws ActivityNotFoundException, NullPointerException {
                         final Intent flick = context.getPackageManager().getLaunchIntentForPackage("com.universallauncher.universallauncher");
                         final Intent flickAction = new Intent("com.universallauncher.universallauncher.FLICK_ICON_PACK_APPLIER");
                         flickAction.putExtra("com.universallauncher.universallauncher.ICON_THEME_PACKAGE", context.getPackageName());
@@ -342,7 +342,7 @@ public class LauncherHelper {
                 new String[]{"com.ss.squarehome2"},
                 new DirectApply() {
                     @Override
-                    public void run(Context context, String packageName) throws ActivityNotFoundException, NullPointerException {
+                    public void run(Context context, String launcherPackageName) throws ActivityNotFoundException, NullPointerException {
                         final Intent square = new Intent("com.ss.squarehome2.ACTION_APPLY_ICONPACK");
                         square.setComponent(ComponentName.unflattenFromString("com.ss.squarehome2/.ApplyThemeActivity"));
                         square.putExtra("com.ss.squarehome2.EXTRA_ICONPACK", context.getPackageName());
@@ -356,7 +356,7 @@ public class LauncherHelper {
                 new String[]{"bitpit.launcher"},
                 new DirectApply() {
                     @Override
-                    public void run(Context context, String packageName) throws ActivityNotFoundException, NullPointerException {
+                    public void run(Context context, String launcherPackageName) throws ActivityNotFoundException, NullPointerException {
                         final Intent niagara = new Intent("bitpit.launcher.APPLY_ICONS");
                         niagara.putExtra("packageName", context.getPackageName());
                         context.startActivity(niagara);
@@ -394,7 +394,7 @@ public class LauncherHelper {
                 new String[]{"com.asus.launcher"},
                 new DirectApply() {
                     @Override
-                    public void run(Context context, String packageName) throws ActivityNotFoundException, NullPointerException {
+                    public void run(Context context, String launcherPackageName) throws ActivityNotFoundException, NullPointerException {
                         final Intent asus = new Intent("com.asus.launcher");
                         asus.setAction("com.asus.launcher.intent.action.APPLY_ICONPACK");
                         asus.addCategory(Intent.CATEGORY_DEFAULT);
@@ -405,9 +405,49 @@ public class LauncherHelper {
                     }
                 });
 
+        /**
+         * Interface for launchers to implement when they support applying icons directly, without
+         * the need to open the icon pack app. The {%code run()} method should be self-contained
+         * and make sure to finish the activity after applying the icon pack.
+         */
         private interface DirectApply {
             default boolean isSupported(String packageName) {return true;}
-            void run(Context context, String packageName) throws ActivityNotFoundException, NullPointerException;
+
+            void run(Context context, String launcherPackageName) throws ActivityNotFoundException, NullPointerException;
+        }
+
+        /**
+         * Interface for launchers to implement when they support icon packs but not direct apply.
+         * They should provide an overall compatibility description and a list of instructions for
+         * users to follow step by step on their device.
+         */
+        private interface ManualApply {
+            /**
+             * The resource ID of the compatibility description string for the launcher. Unless you
+             * have some launcher-specific things to say, you can use the default implementation
+             * which returns a generic description message that works for any launcher.
+             */
+            default String description(Context context, String launcherName) {
+                return context.getResources().getString(
+                        R.string.apply_manual,
+                        launcherName,
+                        context.getResources().getString(R.string.app_name)
+                );
+            }
+
+            /**
+             * A list of resource IDs for the instructions to apply the icon pack manually.
+             * The order of steps in the list matches the order of steps the user will be
+             * presented. Make them concise and easy to follow.
+             *
+             * <p>Example definition:</p>
+             * <pre>{@code
+             * new String[] {
+             *    context.getResources().getString(R.string.apply_manual_step_1), // "Long-tap home screen"
+             *    context.getResources().getString(R.string.apply_manual_step_2), // "Pick %s from the list"
+             * }</pre>
+             */
+            String[] instructionSteps(Context context);
         }
 
         /**
@@ -416,6 +456,8 @@ public class LauncherHelper {
          * as opening Google Play. If you want to open Google Play as a default, take note of the
          * overloaded method `applyDirectly` that accepts a boolean parameter for opening Google
          * Play upon error.
+         *
+         * @see Launcher#applyDirectly(Context, String, boolean)
          */
         public static class LauncherNotInstalledException extends ActivityNotFoundException {
             public LauncherNotInstalledException(Throwable cause) {
@@ -428,7 +470,9 @@ public class LauncherHelper {
          * Exception thrown when the launcher doesn't support applying icon packs directly but if
          * the method `applyDirectly` is called anyway. CandyBar handles this gracefully in-app by
          * showing instructions for how to apply the pack manually. If you see this exception, it
-         * means you forgot to call `supportsDirectApply` before calling `applyDirectly`.
+         * means you forgot to respect `supportsDirectApply` before calling `applyDirectly`.
+         *
+         * @see Launcher#supportsDirectApply(String)
          */
         public static class LauncherDirectApplyNotSupported extends ActivityNotFoundException {
             public LauncherDirectApplyNotSupported(Throwable cause) {
@@ -443,6 +487,8 @@ public class LauncherHelper {
          * a bug report. In the wild, this exception could indicate that the launcher has been
          * updated by the developers and its interface for applying icon packs has changed.
          * For cases when the launcher isn't installed, use `LauncherNotInstalledException`.
+         *
+         * @see LauncherNotInstalledException
          */
         public static class LauncherDirectApplyFailed extends ActivityNotFoundException {
             public LauncherDirectApplyFailed(Throwable cause) {
@@ -457,6 +503,7 @@ public class LauncherHelper {
         public final String[] packages;
         private final boolean directApply;
         private DirectApply directApplyFunc = null;
+        private ManualApply manualApplyFunc = null;
 
         Launcher() {
             this.name = null;
@@ -472,6 +519,23 @@ public class LauncherHelper {
             this.directApply = directApply;
         }
 
+        Launcher(String name, @DrawableRes int icon, String[] packages, ManualApply manualApplyFunc) {
+            this.name = name;
+            this.icon = icon;
+            this.packages = packages;
+            this.directApply = false;
+            this.manualApplyFunc = manualApplyFunc;
+        }
+
+        Launcher(String name, @DrawableRes int icon, String[] packages, DirectApply directApplyFunc, ManualApply manualApplyFunc) {
+            this.name = name;
+            this.icon = icon;
+            this.packages = packages;
+            this.directApply = true;
+            this.directApplyFunc = directApplyFunc;
+            this.manualApplyFunc = manualApplyFunc;
+        }
+
         Launcher(String name, @DrawableRes int icon, String[] packages, DirectApply directApplyFunc) {
             this.name = name;
             this.icon = icon;
@@ -481,7 +545,7 @@ public class LauncherHelper {
         }
 
         /**
-         * Check if the launcher supports to be applied directly. Not all launchers do, and it's
+         * Check if the launcher supports direct apply of icon packs. Not all launchers do, and it's
          * on the launcher developers to provide the necessary interfaces to allow this. Note that
          * when you use `applyDirectly` it's still possible for it to throw an exception (see
          * exception `LauncherDirectApplyFailed`) because newer versions or OS-specific variants of
@@ -498,11 +562,22 @@ public class LauncherHelper {
         }
 
         /**
-         * Try to apply the launcher directly. If the launcher isn't installed, throw an exception.
+         * Tries to apply the icon pack directly. Before calling this, you can ask the launcher with
+         * {@code supportsDirectApply} if it supports this method. Note that this is just a hint,
+         * not a guarantee, so make sure to catch the exceptions thrown by this method and handle
+         * them gracefully.
+         *
+         * <p><b>Credit where credit is due</b></p>
+         * <p>The activities, intents, logic and fallbacks behind this simple method are the
+         * collective work of dozens of open source developers carried out over many years. If you
+         * use this method outside of the CandyBar app, please credit the contributors.</p>
+         *
          * @param launcherPackageName The package name of the launcher to apply the icon pack to.
          * @throws LauncherNotInstalledException If the launcher isn't installed on the device.
          * @throws LauncherDirectApplyNotSupported If the launcher doesn't support applying icon packs directly.
          * @throws LauncherDirectApplyFailed If the icon pack couldn't be applied to the launcher directly. This is never an expected case. If it happens, it might indicate that the launcher interface changed.
+         *
+         * @see Launcher#supportsDirectApply(String)
          */
         public void applyDirectly(Context context, String launcherPackageName) throws ActivityNotFoundException, NullPointerException {
             if (!isInstalled(context, launcherPackageName)) throw new LauncherNotInstalledException(new ActivityNotFoundException());
@@ -516,7 +591,7 @@ public class LauncherHelper {
         }
 
         /**
-         * Try to apply the launcher directly. In case of any errors, open launcher in Google Play.
+         * Try to apply the icon pack directly. In case of any errors, open launcher in Google Play.
          * This is a convenience method to preserve backwards compatibility in CandyBar. If you
          * rather handle exceptions yourself, use `applyDirectly` without the boolean parameter
          * and catch exceptions `LauncherNotInstalledException`, `LauncherDirectApplyFailed` and
@@ -533,6 +608,17 @@ public class LauncherHelper {
                 } else {
                     throw e;
                 }
+            }
+        }
+
+        public void applyManually(Context context, String launcherName, boolean openGooglePlayUponError) {
+            if (manualApplyFunc != null) {
+                applyWithInstructions(
+                        context,
+                        this.name,
+                        this.manualApplyFunc.description(context, launcherName),
+                        this.manualApplyFunc.instructionSteps(context)
+                );
             }
         }
     }

--- a/library/src/main/java/candybar/lib/helpers/LauncherHelper.java
+++ b/library/src/main/java/candybar/lib/helpers/LauncherHelper.java
@@ -206,7 +206,23 @@ public class LauncherHelper {
                 "Nova",
                 R.drawable.ic_launcher_nova,
                 new String[]{"com.teslacoilsw.launcher", "com.teslacoilsw.launcher.prime"},
-                true),
+                new DirectApply() {
+                    @Override
+                    public void run(Context context, String packageName) throws ActivityNotFoundException, NullPointerException {
+                        final Intent nova = new Intent("com.teslacoilsw.launcher.APPLY_ICON_THEME");
+                        nova.setPackage("com.teslacoilsw.launcher");
+                        nova.putExtra("com.teslacoilsw.launcher.extra.ICON_THEME_TYPE", "GO");
+                        nova.putExtra("com.teslacoilsw.launcher.extra.ICON_THEME_PACKAGE", context.getPackageName());
+                        String reshapeSetting = context.getResources().getString(R.string.nova_reshape_legacy_icons);
+                        if (!reshapeSetting.equals("KEEP")) {
+                            // Allowed values are ON, OFF and AUTO
+                            nova.putExtra("com.teslacoilsw.launcher.extra.ICON_THEME_RESHAPE", reshapeSetting);
+                        }
+                        nova.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+                        context.startActivity(nova);
+                        ((AppCompatActivity) context).finish();
+                    }
+                }),
         OXYGEN_OS(
                 "OxygenOS",
                 R.drawable.ic_launcher_oxygen_os,
@@ -707,23 +723,7 @@ public class LauncherHelper {
                 );
                 break;
             case NOVA:
-                try {
-                    final Intent nova = new Intent("com.teslacoilsw.launcher.APPLY_ICON_THEME");
-                    nova.setPackage("com.teslacoilsw.launcher");
-                    nova.putExtra("com.teslacoilsw.launcher.extra.ICON_THEME_TYPE", "GO");
-                    nova.putExtra("com.teslacoilsw.launcher.extra.ICON_THEME_PACKAGE", context.getPackageName());
-                    String reshapeSetting = context.getResources().getString(R.string.nova_reshape_legacy_icons);
-                    if (!reshapeSetting.equals("KEEP")) {
-                        // Allowed values are ON, OFF and AUTO
-                        nova.putExtra("com.teslacoilsw.launcher.extra.ICON_THEME_RESHAPE", reshapeSetting);
-                    }
-                    nova.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-                    context.startActivity(nova);
-                    ((AppCompatActivity) context).finish();
-                    logLauncherDirectApply(launcherPackage);
-                } catch (ActivityNotFoundException | NullPointerException e) {
-                    openGooglePlay(context, launcherPackage, launcherName);
-                }
+                launcher.applyDirectly(context, launcherPackage, true);
                 break;
             case PIXEL:
                 launcherIncompatible(context, launcherName);

--- a/library/src/main/java/candybar/lib/helpers/LauncherHelper.java
+++ b/library/src/main/java/candybar/lib/helpers/LauncherHelper.java
@@ -266,7 +266,19 @@ public class LauncherHelper {
                 "Solo",
                 R.drawable.ic_launcher_solo,
                 new String[]{"home.solo.launcher.free"},
-                true),
+                new DirectApply() {
+                    @Override
+                    public void run(Context context, String packageName) throws ActivityNotFoundException, NullPointerException {
+                        final Intent solo = context.getPackageManager().getLaunchIntentForPackage("home.solo.launcher.free");
+                        final Intent soloAction = new Intent("home.solo.launcher.free.APPLY_THEME");
+                        soloAction.putExtra("EXTRA_THEMENAME", context.getResources().getString(R.string.app_name));
+                        soloAction.putExtra("EXTRA_PACKAGENAME", context.getPackageName());
+                        solo.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+                        context.sendBroadcast(soloAction);
+                        context.startActivity(solo);
+                        ((AppCompatActivity) context).finish();
+                    }
+                }),
         STOCK_LEGACY(
                 /*
                  * Historically, ColorOS, OxygenOS and realme UI were standalone launcher variants
@@ -766,21 +778,7 @@ public class LauncherHelper {
                 launcher.applyDirectly(context, launcherPackage, true);
                 break;
             case SOLO:
-                try {
-                    final Intent solo = context.getPackageManager().getLaunchIntentForPackage(
-                            "home.solo.launcher.free");
-                    final Intent soloAction = new Intent("home.solo.launcher.free.APPLY_THEME");
-                    soloAction.putExtra("EXTRA_THEMENAME", context.getResources().getString(
-                            R.string.app_name));
-                    soloAction.putExtra("EXTRA_PACKAGENAME", context.getPackageName());
-                    solo.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-                    context.sendBroadcast(soloAction);
-                    context.startActivity(solo);
-                    ((AppCompatActivity) context).finish();
-                    logLauncherDirectApply(launcherPackage);
-                } catch (ActivityNotFoundException | NullPointerException e) {
-                    openGooglePlay(context, launcherPackage, launcherName);
-                }
+                launcher.applyDirectly(context, launcherPackage, true);
                 break;
             case SQUARE:
                 try {

--- a/library/src/main/java/candybar/lib/helpers/LauncherHelper.java
+++ b/library/src/main/java/candybar/lib/helpers/LauncherHelper.java
@@ -288,7 +288,15 @@ public class LauncherHelper {
                 "Niagara",
                 R.drawable.ic_launcher_niagara,
                 new String[]{"bitpit.launcher"},
-                true),
+                new DirectApply() {
+                    @Override
+                    public void run(Context context, String packageName) throws ActivityNotFoundException, NullPointerException {
+                        final Intent niagara = new Intent("bitpit.launcher.APPLY_ICONS");
+                        niagara.putExtra("packageName", context.getPackageName());
+                        context.startActivity(niagara);
+                        // FIXME: We never call ((AppCompatActivity) context).finish(); here, is that intentional?
+                    }
+                }),
         HYPERION(
                 "Hyperion",
                 R.drawable.ic_launcher_hyperion,
@@ -676,14 +684,7 @@ public class LauncherHelper {
                 applyManual(context, launcherPackage, launcherName, null);
                 break;
             case NIAGARA:
-                try {
-                    final Intent niagara = new Intent("bitpit.launcher.APPLY_ICONS");
-                    niagara.putExtra("packageName", context.getPackageName());
-                    context.startActivity(niagara);
-                    logLauncherDirectApply(launcherPackage);
-                } catch (ActivityNotFoundException | NullPointerException e) {
-                    openGooglePlay(context, launcherPackage, launcherName);
-                }
+                launcher.applyDirectly(context, launcherPackage, true);
                 break;
             case NOTHING:
                 applyWithInstructions(

--- a/library/src/main/java/candybar/lib/helpers/LauncherHelper.java
+++ b/library/src/main/java/candybar/lib/helpers/LauncherHelper.java
@@ -407,7 +407,7 @@ public class LauncherHelper {
 
         private interface DirectApply {
             default boolean isSupported(String packageName) {return true;}
-            default void run(Context context, String packageName) throws ActivityNotFoundException, NullPointerException {}
+            void run(Context context, String packageName) throws ActivityNotFoundException, NullPointerException;
         }
 
         /**

--- a/library/src/main/java/candybar/lib/helpers/LauncherHelper.java
+++ b/library/src/main/java/candybar/lib/helpers/LauncherHelper.java
@@ -109,7 +109,15 @@ public class LauncherHelper {
                 "CM Theme",
                 R.drawable.ic_launcher_cm,
                 new String[]{"org.cyanogenmod.theme.chooser"},
-                true),
+                new DirectApply() {
+                    @Override
+                    public void run(Context context, String packageName) throws ActivityNotFoundException, NullPointerException {
+                        final Intent cmtheme = new Intent("android.intent.action.MAIN");
+                        cmtheme.setComponent(new ComponentName(packageName, "org.cyanogenmod.theme.chooser.ChooserActivity"));
+                        cmtheme.putExtra("pkgName", context.getPackageName());
+                        context.startActivity(cmtheme);
+                    }
+                }),
         COLOR_OS(
                 "ColorOS",
                 R.drawable.ic_launcher_color_os,
@@ -479,12 +487,7 @@ public class LauncherHelper {
                 break;
             case CMTHEME:
                 try {
-                    final Intent cmtheme = new Intent("android.intent.action.MAIN");
-                    cmtheme.setComponent(new ComponentName(launcherPackage,
-                            "org.cyanogenmod.theme.chooser.ChooserActivity"));
-                    cmtheme.putExtra("pkgName", context.getPackageName());
-                    context.startActivity(cmtheme);
-                    logLauncherDirectApply(launcherPackage);
+                    launcher.applyDirectly(context, launcherPackage, false);
                 } catch (ActivityNotFoundException | NullPointerException e) {
                     Toast.makeText(context, R.string.apply_cmtheme_not_available,
                             Toast.LENGTH_LONG).show();

--- a/library/src/main/java/candybar/lib/helpers/LauncherHelper.java
+++ b/library/src/main/java/candybar/lib/helpers/LauncherHelper.java
@@ -183,7 +183,15 @@ public class LauncherHelper {
                 "Lucid",
                 R.drawable.ic_launcher_lucid,
                 new String[]{"com.powerpoint45.launcher"},
-                true),
+                new DirectApply() {
+                    @Override
+                    public void run(Context context, String packageName) throws ActivityNotFoundException, NullPointerException {
+                        final Intent lucid = new Intent("com.powerpoint45.action.APPLY_THEME", null);
+                        lucid.putExtra("icontheme", context.getPackageName());
+                        context.startActivity(lucid);
+                        ((AppCompatActivity) context).finish();
+                    }
+                }),
         NOTHING(
                 "Nothing",
                 R.drawable.ic_launcher_nothing,
@@ -662,15 +670,7 @@ public class LauncherHelper {
                 launcherIncompatible(context, launcherName);
                 break;
             case LUCID:
-                try {
-                    final Intent lucid = new Intent("com.powerpoint45.action.APPLY_THEME", null);
-                    lucid.putExtra("icontheme", context.getPackageName());
-                    context.startActivity(lucid);
-                    ((AppCompatActivity) context).finish();
-                    logLauncherDirectApply(launcherPackage);
-                } catch (ActivityNotFoundException | NullPointerException e) {
-                    openGooglePlay(context, launcherPackage, launcherName);
-                }
+                launcher.applyDirectly(context, launcherPackage, true);
                 break;
             case MICROSOFT:
                 applyManual(context, launcherPackage, launcherName, null);

--- a/library/src/main/java/candybar/lib/helpers/LauncherHelper.java
+++ b/library/src/main/java/candybar/lib/helpers/LauncherHelper.java
@@ -127,7 +127,19 @@ public class LauncherHelper {
                 "GO EX",
                 R.drawable.ic_launcher_go,
                 new String[]{"com.gau.go.launcherex"},
-                true),
+                new DirectApply() {
+                    @Override
+                    public void run(Context context, String packageName) throws ActivityNotFoundException, NullPointerException {
+                        final Intent goex = context.getPackageManager().getLaunchIntentForPackage("com.gau.go.launcherex");
+                        final Intent go = new Intent("com.gau.go.launcherex.MyThemes.mythemeaction");
+                        go.putExtra("type", 1);
+                        go.putExtra("pkgname", context.getPackageName());
+                        goex.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+                        context.sendBroadcast(go);
+                        context.startActivity(goex);
+                        ((AppCompatActivity) context).finish();
+                    }
+                }),
         HIOS(
                 "HiOS",
                 R.drawable.ic_launcher_hios,
@@ -572,20 +584,7 @@ public class LauncherHelper {
                 launcher.applyDirectly(context, launcherPackage, true);
                 break;
             case GO:
-                try {
-                    final Intent goex = context.getPackageManager().getLaunchIntentForPackage(
-                            "com.gau.go.launcherex");
-                    final Intent go = new Intent("com.gau.go.launcherex.MyThemes.mythemeaction");
-                    go.putExtra("type", 1);
-                    go.putExtra("pkgname", context.getPackageName());
-                    goex.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-                    context.sendBroadcast(go);
-                    context.startActivity(goex);
-                    ((AppCompatActivity) context).finish();
-                    logLauncherDirectApply(launcherPackage);
-                } catch (ActivityNotFoundException | NullPointerException e) {
-                    openGooglePlay(context, launcherPackage, launcherName);
-                }
+                launcher.applyDirectly(context, launcherPackage, true);
                 break;
             case HIOS:
                 applyWithInstructions(

--- a/library/src/main/java/candybar/lib/helpers/LauncherHelper.java
+++ b/library/src/main/java/candybar/lib/helpers/LauncherHelper.java
@@ -238,7 +238,19 @@ public class LauncherHelper {
                 "Flick",
                 R.drawable.ic_launcher_flick,
                 new String[]{"com.universallauncher.universallauncher"},
-                true),
+                new DirectApply() {
+                    @Override
+                    public void run(Context context, String packageName) throws ActivityNotFoundException, NullPointerException {
+                        final Intent flick = context.getPackageManager().getLaunchIntentForPackage("com.universallauncher.universallauncher");
+                        final Intent flickAction = new Intent("com.universallauncher.universallauncher.FLICK_ICON_PACK_APPLIER");
+                        flickAction.putExtra("com.universallauncher.universallauncher.ICON_THEME_PACKAGE", context.getPackageName());
+                        flickAction.setComponent(new ComponentName("com.universallauncher.universallauncher", "com.android.launcher3.icon.ApplyIconPack"));
+                        flick.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+                        context.sendBroadcast(flickAction);
+                        context.startActivity(flick);
+                        ((AppCompatActivity) context).finish();
+                    }
+                }),
         SQUARE(
                 "Square",
                 R.drawable.ic_launcher_square,
@@ -557,19 +569,7 @@ public class LauncherHelper {
                 }
                 break;
             case FLICK:
-                try {
-                    final Intent flick = context.getPackageManager().getLaunchIntentForPackage("com.universallauncher.universallauncher");
-                    final Intent flickAction = new Intent("com.universallauncher.universallauncher.FLICK_ICON_PACK_APPLIER");
-                    flickAction.putExtra("com.universallauncher.universallauncher.ICON_THEME_PACKAGE", context.getPackageName());
-                    flickAction.setComponent(new ComponentName("com.universallauncher.universallauncher", "com.android.launcher3.icon.ApplyIconPack"));
-                    flick.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-                    context.sendBroadcast(flickAction);
-                    context.startActivity(flick);
-                    ((AppCompatActivity) context).finish();
-                    logLauncherDirectApply(launcherPackage);
-                } catch (ActivityNotFoundException | NullPointerException e) {
-                    openGooglePlay(context, launcherPackage, launcherName);
-                }
+                launcher.applyDirectly(context, launcherPackage, true);
                 break;
             case GO:
                 try {

--- a/library/src/main/java/candybar/lib/helpers/LauncherHelper.java
+++ b/library/src/main/java/candybar/lib/helpers/LauncherHelper.java
@@ -95,7 +95,16 @@ public class LauncherHelper {
                 "Before",
                 R.drawable.ic_launcher_before,
                 new String[]{"com.beforesoft.launcher"},
-                true),
+                new DirectApply() {
+                    @Override
+                    public void run(Context context, String packageName) throws ActivityNotFoundException, NullPointerException {
+                        final Intent before = new Intent("com.beforesoftware.launcher.APPLY_ICONS");
+                        before.putExtra("packageName", context.getPackageName());
+                        before.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+                        context.startActivity(before);
+                        ((AppCompatActivity) context).finish();
+                    }
+                }),
         CMTHEME(
                 "CM Theme",
                 R.drawable.ic_launcher_cm,
@@ -446,12 +455,7 @@ public class LauncherHelper {
                 break;
             case BEFORE:
                 try {
-                    final Intent before = new Intent("com.beforesoftware.launcher.APPLY_ICONS");
-                    before.putExtra("packageName", context.getPackageName());
-                    before.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-                    context.startActivity(before);
-                    ((AppCompatActivity) context).finish();
-                    logLauncherDirectApply(launcherPackage);
+                    launcher.applyDirectly(context, launcherPackage, false);
                 } catch (ActivityNotFoundException | NullPointerException e) {
                     applyWithInstructions(
                             context,

--- a/library/src/main/java/candybar/lib/helpers/LauncherHelper.java
+++ b/library/src/main/java/candybar/lib/helpers/LauncherHelper.java
@@ -297,6 +297,17 @@ public class LauncherHelper {
         applyLauncher(context, packageName, launcherName, getLauncher(packageName));
     }
 
+    private static void logLauncherDirectApply(String launcherPackage) {
+        CandyBarApplication.getConfiguration().getAnalyticsHandler().logEvent(
+                "click",
+                new HashMap<>() {{
+                    put("section", "apply");
+                    put("action", "confirm");
+                    put("launcher", launcherPackage);
+                }}
+        );
+    }
+
     private static void applyLauncher(@NonNull Context context, String launcherPackage, String launcherName, Launcher launcher) {
         switch (launcher) {
             case ACTION:
@@ -307,14 +318,7 @@ public class LauncherHelper {
                     action.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
                     context.startActivity(action);
                     ((AppCompatActivity) context).finish();
-                    CandyBarApplication.getConfiguration().getAnalyticsHandler().logEvent(
-                            "click",
-                            new HashMap<String, Object>() {{
-                                put("section", "apply");
-                                put("action", "confirm");
-                                put("launcher", launcherPackage);
-                            }}
-                    );
+                    logLauncherDirectApply(launcherPackage);
                 } catch (ActivityNotFoundException | NullPointerException e) {
                     openGooglePlay(context, launcherPackage, launcherName);
                 }
@@ -326,14 +330,7 @@ public class LauncherHelper {
                     adw.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
                     context.startActivity(adw);
                     ((AppCompatActivity) context).finish();
-                    CandyBarApplication.getConfiguration().getAnalyticsHandler().logEvent(
-                            "click",
-                            new HashMap<String, Object>() {{
-                                put("section", "apply");
-                                put("action", "confirm");
-                                put("launcher", launcherPackage);
-                            }}
-                    );
+                    logLauncherDirectApply(launcherPackage);
                 } catch (ActivityNotFoundException | NullPointerException e) {
                     openGooglePlay(context, launcherPackage, launcherName);
                 }
@@ -345,14 +342,7 @@ public class LauncherHelper {
                     apex.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
                     context.startActivity(apex);
                     ((AppCompatActivity) context).finish();
-                    CandyBarApplication.getConfiguration().getAnalyticsHandler().logEvent(
-                            "click",
-                            new HashMap<String, Object>() {{
-                                put("section", "apply");
-                                put("action", "confirm");
-                                put("launcher", launcherPackage);
-                            }}
-                    );
+                    logLauncherDirectApply(launcherPackage);
                 } catch (ActivityNotFoundException | NullPointerException e) {
                     openGooglePlay(context, launcherPackage, launcherName);
                 }
@@ -364,14 +354,7 @@ public class LauncherHelper {
                     before.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
                     context.startActivity(before);
                     ((AppCompatActivity) context).finish();
-                    CandyBarApplication.getConfiguration().getAnalyticsHandler().logEvent(
-                            "click",
-                            new HashMap<String, Object>() {{
-                                put("section", "apply");
-                                put("action", "confirm");
-                                put("launcher", launcherPackage);
-                            }}
-                    );
+                    logLauncherDirectApply(launcherPackage);
                 } catch (ActivityNotFoundException | NullPointerException e) {
                     applyWithInstructions(
                             context,
@@ -400,14 +383,7 @@ public class LauncherHelper {
                             "org.cyanogenmod.theme.chooser.ChooserActivity"));
                     cmtheme.putExtra("pkgName", context.getPackageName());
                     context.startActivity(cmtheme);
-                    CandyBarApplication.getConfiguration().getAnalyticsHandler().logEvent(
-                            "click",
-                            new HashMap<String, Object>() {{
-                                put("section", "apply");
-                                put("action", "confirm");
-                                put("launcher", launcherPackage);
-                            }}
-                    );
+                    logLauncherDirectApply(launcherPackage);
                 } catch (ActivityNotFoundException | NullPointerException e) {
                     Toast.makeText(context, R.string.apply_cmtheme_not_available,
                             Toast.LENGTH_LONG).show();
@@ -486,14 +462,7 @@ public class LauncherHelper {
                     context.sendBroadcast(flickAction);
                     context.startActivity(flick);
                     ((AppCompatActivity) context).finish();
-                    CandyBarApplication.getConfiguration().getAnalyticsHandler().logEvent(
-                            "click",
-                            new HashMap<String, Object>() {{
-                                put("section", "apply");
-                                put("action", "confirm");
-                                put("launcher", launcherPackage);
-                            }}
-                    );
+                    logLauncherDirectApply(launcherPackage);
                 } catch (ActivityNotFoundException | NullPointerException e) {
                     openGooglePlay(context, launcherPackage, launcherName);
                 }
@@ -509,14 +478,7 @@ public class LauncherHelper {
                     context.sendBroadcast(go);
                     context.startActivity(goex);
                     ((AppCompatActivity) context).finish();
-                    CandyBarApplication.getConfiguration().getAnalyticsHandler().logEvent(
-                            "click",
-                            new HashMap<String, Object>() {{
-                                put("section", "apply");
-                                put("action", "confirm");
-                                put("launcher", launcherPackage);
-                            }}
-                    );
+                    logLauncherDirectApply(launcherPackage);
                 } catch (ActivityNotFoundException | NullPointerException e) {
                     openGooglePlay(context, launcherPackage, launcherName);
                 }
@@ -590,14 +552,7 @@ public class LauncherHelper {
                     lawnchair.putExtra("packageName", context.getPackageName());
                     context.startActivity(lawnchair);
                     ((AppCompatActivity) context).finish();
-                    CandyBarApplication.getConfiguration().getAnalyticsHandler().logEvent(
-                            "click",
-                            new HashMap<String, Object>() {{
-                                put("section", "apply");
-                                put("action", "confirm");
-                                put("launcher", launcherPackage);
-                            }}
-                    );
+                    logLauncherDirectApply(launcherPackage);
                 } catch (ActivityNotFoundException | NullPointerException e) {
                     openGooglePlay(context, launcherPackage, launcherName);
                 }
@@ -611,14 +566,7 @@ public class LauncherHelper {
                     lucid.putExtra("icontheme", context.getPackageName());
                     context.startActivity(lucid);
                     ((AppCompatActivity) context).finish();
-                    CandyBarApplication.getConfiguration().getAnalyticsHandler().logEvent(
-                            "click",
-                            new HashMap<String, Object>() {{
-                                put("section", "apply");
-                                put("action", "confirm");
-                                put("launcher", launcherPackage);
-                            }}
-                    );
+                    logLauncherDirectApply(launcherPackage);
                 } catch (ActivityNotFoundException | NullPointerException e) {
                     openGooglePlay(context, launcherPackage, launcherName);
                 }
@@ -631,14 +579,7 @@ public class LauncherHelper {
                     final Intent niagara = new Intent("bitpit.launcher.APPLY_ICONS");
                     niagara.putExtra("packageName", context.getPackageName());
                     context.startActivity(niagara);
-                    CandyBarApplication.getConfiguration().getAnalyticsHandler().logEvent(
-                            "click",
-                            new HashMap<String, Object>() {{
-                                put("section", "apply");
-                                put("action", "confirm");
-                                put("launcher", launcherPackage);
-                            }}
-                    );
+                    logLauncherDirectApply(launcherPackage);
                 } catch (ActivityNotFoundException | NullPointerException e) {
                     openGooglePlay(context, launcherPackage, launcherName);
                 }
@@ -677,14 +618,7 @@ public class LauncherHelper {
                     nova.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
                     context.startActivity(nova);
                     ((AppCompatActivity) context).finish();
-                    CandyBarApplication.getConfiguration().getAnalyticsHandler().logEvent(
-                            "click",
-                            new HashMap<String, Object>() {{
-                                put("section", "apply");
-                                put("action", "confirm");
-                                put("launcher", launcherPackage);
-                            }}
-                    );
+                    logLauncherDirectApply(launcherPackage);
                 } catch (ActivityNotFoundException | NullPointerException e) {
                     openGooglePlay(context, launcherPackage, launcherName);
                 }
@@ -703,14 +637,7 @@ public class LauncherHelper {
                     projectivy.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
                     context.startActivity(projectivy);
                     ((AppCompatActivity) context).finish();
-                    CandyBarApplication.getConfiguration().getAnalyticsHandler().logEvent(
-                            "click",
-                            new HashMap<String, Object>() {{
-                                put("section", "apply");
-                                put("action", "confirm");
-                                put("launcher", launcherPackage);
-                            }}
-                    );
+                    logLauncherDirectApply(launcherPackage);
                 } catch (ActivityNotFoundException | NullPointerException e) {
                     openGooglePlay(context, launcherPackage, launcherName);
                 }
@@ -731,14 +658,7 @@ public class LauncherHelper {
                     smart.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
                     context.startActivity(smart);
                     ((AppCompatActivity) context).finish();
-                    CandyBarApplication.getConfiguration().getAnalyticsHandler().logEvent(
-                            "click",
-                            new HashMap<String, Object>() {{
-                                put("section", "apply");
-                                put("action", "confirm");
-                                put("launcher", launcherPackage);
-                            }}
-                    );
+                    logLauncherDirectApply(launcherPackage);
                 } catch (ActivityNotFoundException | NullPointerException e) {
                     openGooglePlay(context, launcherPackage, launcherName);
                 }
@@ -755,14 +675,7 @@ public class LauncherHelper {
                     context.sendBroadcast(soloAction);
                     context.startActivity(solo);
                     ((AppCompatActivity) context).finish();
-                    CandyBarApplication.getConfiguration().getAnalyticsHandler().logEvent(
-                            "click",
-                            new HashMap<String, Object>() {{
-                                put("section", "apply");
-                                put("action", "confirm");
-                                put("launcher", launcherPackage);
-                            }}
-                    );
+                    logLauncherDirectApply(launcherPackage);
                 } catch (ActivityNotFoundException | NullPointerException e) {
                     openGooglePlay(context, launcherPackage, launcherName);
                 }
@@ -773,14 +686,7 @@ public class LauncherHelper {
                     square.setComponent(ComponentName.unflattenFromString("com.ss.squarehome2/.ApplyThemeActivity"));
                     square.putExtra("com.ss.squarehome2.EXTRA_ICONPACK", context.getPackageName());
                     context.startActivity(square);
-                    CandyBarApplication.getConfiguration().getAnalyticsHandler().logEvent(
-                            "click",
-                            new HashMap<String, Object>() {{
-                                put("section", "apply");
-                                put("action", "confirm");
-                                put("launcher", launcherPackage);
-                            }}
-                    );
+                    logLauncherDirectApply(launcherPackage);
                 } catch (ActivityNotFoundException | NullPointerException e) {
                     openGooglePlay(context, launcherPackage, launcherName);
                 }
@@ -819,14 +725,7 @@ public class LauncherHelper {
                     nougat.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
                     context.startActivity(nougat);
                     ((AppCompatActivity) context).finish();
-                    CandyBarApplication.getConfiguration().getAnalyticsHandler().logEvent(
-                            "click",
-                            new HashMap<String, Object>() {{
-                                put("section", "apply");
-                                put("action", "confirm");
-                                put("launcher", launcherPackage);
-                            }}
-                    );
+                    logLauncherDirectApply(launcherPackage);
                 } catch (ActivityNotFoundException | NullPointerException e) {
                     openGooglePlay(context, launcherPackage, launcherName);
                 }
@@ -840,14 +739,7 @@ public class LauncherHelper {
                     asus.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
                     context.startActivity(asus);
                     ((AppCompatActivity) context).finish();
-                    CandyBarApplication.getConfiguration().getAnalyticsHandler().logEvent(
-                            "click",
-                            new HashMap<String, Object>() {{
-                                put("section", "apply");
-                                put("action", "confirm");
-                                put("launcher", launcherPackage);
-                            }}
-                    );
+                    logLauncherDirectApply(launcherPackage);
                 } catch (ActivityNotFoundException | NullPointerException e) {
                     openGooglePlay(context, launcherPackage, launcherName);
                 }

--- a/library/src/main/java/candybar/lib/helpers/LauncherHelper.java
+++ b/library/src/main/java/candybar/lib/helpers/LauncherHelper.java
@@ -81,7 +81,16 @@ public class LauncherHelper {
                 "Apex",
                 R.drawable.ic_launcher_apex,
                 new String[]{"com.anddoes.launcher", "com.anddoes.launcher.pro"},
-                true),
+                new DirectApply() {
+                    @Override
+                    public void run(Context context, String packageName) throws ActivityNotFoundException, NullPointerException {
+                        final Intent apex = new Intent("com.anddoes.launcher.SET_THEME");
+                        apex.putExtra("com.anddoes.launcher.THEME_PACKAGE_NAME", context.getPackageName());
+                        apex.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+                        context.startActivity(apex);
+                        ((AppCompatActivity) context).finish();
+                    }
+                }),
         BEFORE(
                 "Before",
                 R.drawable.ic_launcher_before,
@@ -433,16 +442,7 @@ public class LauncherHelper {
                 launcher.applyDirectly(context, launcherPackage, true);
                 break;
             case APEX:
-                try {
-                    final Intent apex = new Intent("com.anddoes.launcher.SET_THEME");
-                    apex.putExtra("com.anddoes.launcher.THEME_PACKAGE_NAME", context.getPackageName());
-                    apex.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-                    context.startActivity(apex);
-                    ((AppCompatActivity) context).finish();
-                    logLauncherDirectApply(launcherPackage);
-                } catch (ActivityNotFoundException | NullPointerException e) {
-                    openGooglePlay(context, launcherPackage, launcherName);
-                }
+                launcher.applyDirectly(context, launcherPackage, true);
                 break;
             case BEFORE:
                 try {

--- a/library/src/main/java/candybar/lib/helpers/LauncherHelper.java
+++ b/library/src/main/java/candybar/lib/helpers/LauncherHelper.java
@@ -66,7 +66,17 @@ public class LauncherHelper {
                 "ADW",
                 R.drawable.ic_launcher_adw,
                 new String[]{"org.adw.launcher", "org.adwfreak.launcher"},
-                true),
+                new DirectApply() {
+                    @Override
+                    public void run(Context context, String packageName) throws ActivityNotFoundException, NullPointerException {
+                        final Intent adw = new Intent("org.adw.launcher.SET_THEME");
+                        adw.putExtra("org.adw.launcher.theme.NAME", context.getPackageName());
+                        adw.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+                        context.startActivity(adw);
+                        ((AppCompatActivity) context).finish();
+                    }
+                }
+        ),
         APEX(
                 "Apex",
                 R.drawable.ic_launcher_apex,
@@ -420,16 +430,7 @@ public class LauncherHelper {
                 launcher.applyDirectly(context, launcherPackage, true);
                 break;
             case ADW:
-                try {
-                    final Intent adw = new Intent("org.adw.launcher.SET_THEME");
-                    adw.putExtra("org.adw.launcher.theme.NAME", context.getPackageName());
-                    adw.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-                    context.startActivity(adw);
-                    ((AppCompatActivity) context).finish();
-                    logLauncherDirectApply(launcherPackage);
-                } catch (ActivityNotFoundException | NullPointerException e) {
-                    openGooglePlay(context, launcherPackage, launcherName);
-                }
+                launcher.applyDirectly(context, launcherPackage, true);
                 break;
             case APEX:
                 try {

--- a/library/src/main/java/candybar/lib/helpers/LauncherHelper.java
+++ b/library/src/main/java/candybar/lib/helpers/LauncherHelper.java
@@ -165,6 +165,14 @@ public class LauncherHelper {
                         // Lawnchair 12 (app.lawnchair) doesn't support direct apply
                         return !packageName.startsWith("app");
                     }
+
+                    @Override
+                    public void run(Context context, String packageName) throws ActivityNotFoundException, NullPointerException {
+                        final Intent lawnchair = new Intent("ch.deletescape.lawnchair.APPLY_ICONS", null);
+                        lawnchair.putExtra("packageName", context.getPackageName());
+                        context.startActivity(lawnchair);
+                        ((AppCompatActivity) context).finish();
+                    }
                 }),
         LGHOME(
                 "LG Home",
@@ -644,20 +652,10 @@ public class LauncherHelper {
                 );
                 break;
             case LAWNCHAIR:
-                if (launcherPackage.startsWith("app")) {
-                    // Lawnchair 12 (app.lawnchair) does not support direct apply yet
+                if (launcher.supportsDirectApply(launcherPackage)) {
+                    launcher.applyDirectly(context, launcherPackage, true);
+                } else {
                     applyManual(context, launcherPackage, launcherName, "app.lawnchair.ui.preferences.PreferenceActivity");
-                    break;
-                }
-
-                try {
-                    final Intent lawnchair = new Intent("ch.deletescape.lawnchair.APPLY_ICONS", null);
-                    lawnchair.putExtra("packageName", context.getPackageName());
-                    context.startActivity(lawnchair);
-                    ((AppCompatActivity) context).finish();
-                    logLauncherDirectApply(launcherPackage);
-                } catch (ActivityNotFoundException | NullPointerException e) {
-                    openGooglePlay(context, launcherPackage, launcherName);
                 }
                 break;
             case LGHOME:

--- a/library/src/main/java/candybar/lib/helpers/LauncherHelper.java
+++ b/library/src/main/java/candybar/lib/helpers/LauncherHelper.java
@@ -51,7 +51,17 @@ public class LauncherHelper {
                 "Action",
                 R.drawable.ic_launcher_action,
                 new String[]{"com.actionlauncher.playstore", "com.chrislacy.actionlauncher.pro"},
-                true),
+                new DirectApply() {
+                    @Override
+                    public void run(Context context, String packageName) throws ActivityNotFoundException, NullPointerException {
+                        final Intent action = context.getPackageManager().getLaunchIntentForPackage(packageName);
+                        action.putExtra("apply_icon_pack", context.getPackageName());
+                        action.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+                        context.startActivity(action);
+                        ((AppCompatActivity) context).finish();
+                    }
+                }
+        ),
         ADW(
                 "ADW",
                 R.drawable.ic_launcher_adw,
@@ -407,17 +417,7 @@ public class LauncherHelper {
     private static void applyLauncher(@NonNull Context context, String launcherPackage, String launcherName, Launcher launcher) {
         switch (launcher) {
             case ACTION:
-                try {
-                    final Intent action = context.getPackageManager().getLaunchIntentForPackage(
-                            launcherPackage);
-                    action.putExtra("apply_icon_pack", context.getPackageName());
-                    action.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-                    context.startActivity(action);
-                    ((AppCompatActivity) context).finish();
-                    logLauncherDirectApply(launcherPackage);
-                } catch (ActivityNotFoundException | NullPointerException e) {
-                    openGooglePlay(context, launcherPackage, launcherName);
-                }
+                launcher.applyDirectly(context, launcherPackage, true);
                 break;
             case ADW:
                 try {


### PR DESCRIPTION
This PR is a big refactoring accomplishing two things:
1. All information that we have about launchers is now neatly encapsulated. Most notably, calling apps can use these methods:
   * `supportsIconPacks`
   * `supportsDirectApply`
   * `supportsManualApply`
   * `applyDirectly`
   * `applyManually`
2. There's now a standard flow of events that all launchers adhere to automatically. No more forgetting `((AppCompatActivity) context).finish()` and no more ambiguity whether Google Play is opened as a fallback. :) It's now easier than ever to spot if launchers are missing information. For example Blackberry where we used to open the `MainActivity` but without any instructions whatsoever. Fixing this is out of scope of this PR but it's now a clearly visible flaw in the definition.

If more freedom is necessary, launchers also offer `DirectApply.getActivity` (and `DirectApply.getBroadcast` if necessary) and `ManualApply.getInstructionSteps`.

### Why?

After 3 years of using CandyBar, I now feel like I've outgrown the UI and Icon Request mechanics but I don't want to make a whole new fork of the library. Instead, I want to keep CandyBar as a dependency and leverage the sane defaults for the icon picker, etc., but build a new UI on top. :)