### PR TITLE
Fix Keyboard handling

### DIFF
--- a/library/src/main/java/candybar/lib/fragments/WallpapersFragment.java
+++ b/library/src/main/java/candybar/lib/fragments/WallpapersFragment.java
@@ -147,14 +147,6 @@ public class WallpapersFragment extends Fragment {
         View clearQueryButton = searchView.findViewById(R.id.clear_query_button);
 
         searchInput.setHint(requireActivity().getResources().getString(R.string.search_wallpapers));
-        searchInput.requestFocus();
-
-        new Handler(Looper.getMainLooper()).postDelayed(() -> {
-            if (getActivity() != null) {
-                SoftKeyboardHelper.openKeyboard(getActivity());
-            }
-        }, 1000);
-
         searchInput.addTextChangedListener(new TextWatcher() {
             @Override
             public void beforeTextChanged(CharSequence charSequence, int i, int i1, int i2) {
@@ -183,7 +175,7 @@ public class WallpapersFragment extends Fragment {
                     if (getActivity() != null) {
                         SoftKeyboardHelper.openKeyboard(getActivity());
                     }
-                }, 1000);
+                }, 300);
 
                 return true;
             }
@@ -191,6 +183,11 @@ public class WallpapersFragment extends Fragment {
             @Override
             public boolean onMenuItemActionCollapse(MenuItem menuItem) {
                 searchInput.setText("");
+                new Handler(Looper.getMainLooper()).postDelayed(() -> {
+                if (getActivity() != null) {
+                    SoftKeyboardHelper.closeKeyboard(getActivity());
+                }
+                }, 300);
                 return true;
             }
         });


### PR DESCRIPTION
If the tutorial is active and you enter the wallpapers view the keyboard pops up.
This fixes it and it also hides the keyboard if exiting search.