### PR TITLE
Fix white status bar on Android 9 and below

### DIFF
--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -4,6 +4,8 @@
         <item name="cb_colorPrimary">#222222</item>
         <item name="cb_colorPrimaryDark">#222222</item>
         <item name="cb_colorAccent">#1BB96F</item>
+        <!-- Fallback status bar color for Android 9 and below -->
+        <item name="android:statusBarColor">?attr/cb_colorPrimary</item>
 
         <!-- Navigation Bar -->
         <item name="cb_navigationBar">#222222</item>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -4,6 +4,8 @@
         <item name="cb_colorPrimary">#35C164</item>
         <item name="cb_colorPrimaryDark">#4CAF50</item>
         <item name="cb_colorAccent">#1BB96F</item>
+        <!-- Fallback status bar color for Android 9 and below -->
+        <item name="android:statusBarColor">?attr/cb_colorPrimary</item>
 
         <!-- Navigation Bar -->
         <item name="cb_navigationBar">#1A73E9</item>


### PR DESCRIPTION
This PR fixes the “white status bar” issue reported in #183 on devices running Android 9 (API 28) and below.

The status bar area appears as a solid white strip on Android 9 and below. On Android 10+ with edge‑to‑edge layouts the bug is not visible.

This uses the existing cb_colorPrimary theme attribute so the status bar color follows the dashboard’s primary color and stays customizable for icon pack devs.
- Fixes the white status bar on Android 9 and below.
- Keeps dynamic theming intact: icon pack developers can still override cb_colorPrimary in their own themes.
- No behaviour change for Android 10+ devices that already override android:statusBarColor with edge-to-edge layout theming.

Fixes #183