### PR TITLE
Introduce icon tags for search

### DIFF
--- a/app/src/main/res/values/dashboard_configurations.xml
+++ b/app/src/main/res/values/dashboard_configurations.xml
@@ -41,6 +41,7 @@
 
     <!-- CONFIG: ICONS -->
     <bool name="enable_icons_sort">false</bool>
+    <bool name="enable_icons_tag_search">true</bool>
     <bool name="show_icon_name">true</bool>
     <bool name="includes_adaptive_icons">true</bool>
 

--- a/app/src/main/res/values/dashboard_configurations.xml
+++ b/app/src/main/res/values/dashboard_configurations.xml
@@ -42,6 +42,7 @@
     <!-- CONFIG: ICONS -->
     <bool name="enable_icons_sort">false</bool>
     <bool name="enable_icons_tag_search">true</bool>
+    <bool name="enable_icons_substring_search">true</bool>
     <bool name="show_icon_name">true</bool>
     <bool name="includes_adaptive_icons">true</bool>
 

--- a/app/src/main/res/values/search_tags.xml
+++ b/app/src/main/res/values/search_tags.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Translatable tag values for the icon tag search.
+
+    Reference them from res/xml/icon_tags.xml with @string/tag_name.
+    Search runs against the translated value, so a German user
+    searching "kamera" will find an icon tagged @string/tag_camera
+    if that string is translated accordingly.
+-->
+<resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation">
+    <string name="tag_energy">energy</string>
+    <string name="tag_weather">weather</string>
+    <string name="tag_battery">battery</string>
+    <string name="tag_sun">sun</string>
+    <string name="tag_green">green</string>
+    <string name="tag_orange">orange</string>
+</resources>

--- a/app/src/main/res/xml/icon_tags.xml
+++ b/app/src/main/res/xml/icon_tags.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Example tag map for improved icon search.
+
+    Each <icon> points at a drawable and lists the tags a user might search for
+    to find it. Tags usually reference @string/... values (kept in
+    res/values/search_tags.xml) so they can be translated. Useful if an app
+    title is "camera" but a German user might rather search for "Kamera".
+
+    Adding, removing, or changing entries here needs no code change.
+    The tag search rebuilds its index from this file.
+
+    All entries are case-insensitive.
+-->
+<icons>
+    <icon drawable="@drawable/accubattery">
+        <tag value="@string/tag_energy" />
+        <tag value="@string/tag_battery" />
+        <tag value="@string/tag_green" />
+    </icon>
+    <icon drawable="@drawable/accuweather">
+        <tag value="@string/tag_sun" />
+        <tag value="@string/tag_orange" />
+        <tag value="@string/tag_weather" />
+    </icon>
+</icons>

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -105,6 +105,10 @@ dependencies {
     api 'dev.jahir.KustomAPI:api:6369c37'
     api 'dev.jahir.KustomAPI:preset:6369c37'
 
+    // Local, on device search index used by the icon tag search (see candybar.lib.search)
+    api 'androidx.appsearch:appsearch:1.1.0'
+    implementation 'androidx.appsearch:appsearch-local-storage:1.1.0'
+
     implementation 'androidx.work:work-runtime:2.10.5'
     implementation 'androidx.recyclerview:recyclerview:1.4.0'
     implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.1.0'

--- a/library/src/main/AndroidManifest.xml
+++ b/library/src/main/AndroidManifest.xml
@@ -72,6 +72,11 @@
         <service
             android:name="candybar.lib.services.CandyBarService"
             android:stopWithTask="false" />
+
+        <provider
+            android:name="candybar.lib.providers.IconsProvider"
+            android:authorities="${applicationId}.icons"
+            android:exported="true" />
     </application>
 
 </manifest>

--- a/library/src/main/java/candybar/lib/adapters/IconsAdapter.java
+++ b/library/src/main/java/candybar/lib/adapters/IconsAdapter.java
@@ -395,11 +395,29 @@ public class IconsAdapter extends RecyclerView.Adapter<IconsAdapter.ViewHolder> 
         if (query.isEmpty()) mIcons.addAll(mIconsAll);
         else {
             for (int i = 0; i < mIconsAll.size(); i++) {
+                // Classic search by title
                 Icon icon = mIconsAll.get(i);
                 String name = icon.getTitle();
                 name = name.toLowerCase(Locale.ENGLISH);
                 if (name.contains(query)) {
                     mIcons.add(icon);
+                    continue; // Match found, nothing else to do
+                }
+                if (icon.getTags() == null)
+                    continue; // No tags, no need to compute
+
+                for (String tag : icon.getTags()) {
+                    if (query.length() == 1) { // Only 1 letter, use exact match!
+                        if (tag.equalsIgnoreCase(query)) {
+                            mIcons.add(icon);
+                            break;
+                        }
+                    } else { // Query with 2 or more characters, use substring match!
+                        if (tag.contains(query)) {
+                            mIcons.add(icon);
+                            break;
+                        }
+                    }
                 }
             }
         }

--- a/library/src/main/java/candybar/lib/adapters/IconsAdapter.java
+++ b/library/src/main/java/candybar/lib/adapters/IconsAdapter.java
@@ -394,32 +394,8 @@ public class IconsAdapter extends RecyclerView.Adapter<IconsAdapter.ViewHolder> 
         mIcons = new ArrayList<>();
         if (query.isEmpty()) mIcons.addAll(mIconsAll);
         else {
-            for (int i = 0; i < mIconsAll.size(); i++) {
-                // Classic search by title
-                Icon icon = mIconsAll.get(i);
-                String name = icon.getTitle();
-                name = name.toLowerCase(Locale.ENGLISH);
-                if (name.contains(query)) {
-                    mIcons.add(icon);
-                    continue; // Match found, nothing else to do
-                }
-                if (icon.getTags() == null)
-                    continue; // No tags, no need to compute
-
-                for (String tag : icon.getTags()) {
-                    if (query.length() == 1) { // Only 1 letter, use exact match!
-                        if (tag.equalsIgnoreCase(query)) {
-                            mIcons.add(icon);
-                            break;
-                        }
-                    } else { // Query with 2 or more characters, use substring match!
-                        if (tag.contains(query)) {
-                            mIcons.add(icon);
-                            break;
-                        }
-                    }
-                }
-            }
+            boolean substring = mContext.getResources().getBoolean(R.bool.enable_icons_substring_search);
+            mIcons = IconsHelper.search(mContext, query, substring);
         }
 
         if (mIcons.isEmpty()) {

--- a/library/src/main/java/candybar/lib/adapters/IconsAdapter.java
+++ b/library/src/main/java/candybar/lib/adapters/IconsAdapter.java
@@ -389,7 +389,7 @@ public class IconsAdapter extends RecyclerView.Adapter<IconsAdapter.ViewHolder> 
             mIconsAll = mIcons;
         }
 
-        String query = string.toLowerCase(Locale.ENGLISH).trim();
+        String query = string.toLowerCase(Locale.getDefault()).trim();
 
         mIcons = new ArrayList<>();
         if (query.isEmpty()) mIcons.addAll(mIconsAll);

--- a/library/src/main/java/candybar/lib/applications/CandyBarApplication.java
+++ b/library/src/main/java/candybar/lib/applications/CandyBarApplication.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import candybar.lib.R;
 import candybar.lib.activities.CandyBarCrashReport;
 import candybar.lib.databases.Database;
+import candybar.lib.helpers.AppSearchHelper;
 import candybar.lib.helpers.LocaleHelper;
 import candybar.lib.items.Request;
 import candybar.lib.preferences.Preferences;
@@ -89,6 +90,7 @@ public abstract class CandyBarApplication extends Application {
         }
 
         LocaleHelper.setLocale(this);
+        AppSearchHelper.getInstance(this).initAsync(this);
     }
 
     private void handleUncaughtException(Thread thread, Throwable throwable) {

--- a/library/src/main/java/candybar/lib/helpers/AppSearchHelper.java
+++ b/library/src/main/java/candybar/lib/helpers/AppSearchHelper.java
@@ -21,9 +21,11 @@ import com.google.common.util.concurrent.ListenableFuture;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -114,7 +116,7 @@ public class AppSearchHelper {
     private void setupSchema(AppSearchSession session) throws Exception {
         AppSearchSchema iconSchema = new AppSearchSchema.Builder("Icon")
                 .addProperty(new StringPropertyConfig.Builder("drawableName")
-                        .setCardinality(PropertyConfig.CARDINALITY_OPTIONAL)
+                        .setCardinality(PropertyConfig.CARDINALITY_REQUIRED)
                         .build())
                 .addProperty(new StringPropertyConfig.Builder("title")
                         .setCardinality(PropertyConfig.CARDINALITY_OPTIONAL)
@@ -127,10 +129,8 @@ public class AppSearchHelper {
                 .addProperty(new LongPropertyConfig.Builder("resId")
                         .setCardinality(PropertyConfig.CARDINALITY_REQUIRED)
                         .build())
-                .addProperty(new StringPropertyConfig.Builder("category")
-                        .setCardinality(PropertyConfig.CARDINALITY_OPTIONAL)
-                        .setIndexingType(StringPropertyConfig.INDEXING_TYPE_EXACT_TERMS)
-                        .setTokenizerType(StringPropertyConfig.TOKENIZER_TYPE_PLAIN)
+                .addProperty(new StringPropertyConfig.Builder("categories")
+                        .setCardinality(PropertyConfig.CARDINALITY_REPEATED)
                         .build())
                 .addProperty(new StringPropertyConfig.Builder("tags")
                         .setCardinality(PropertyConfig.CARDINALITY_REPEATED)
@@ -141,7 +141,7 @@ public class AppSearchHelper {
 
         AppSearchSchema categorySchema = new AppSearchSchema.Builder("Category")
                 .addProperty(new StringPropertyConfig.Builder("categoryName")
-                        .setCardinality(PropertyConfig.CARDINALITY_OPTIONAL)
+                        .setCardinality(PropertyConfig.CARDINALITY_REQUIRED)
                         .build())
                 .addProperty(new LongPropertyConfig.Builder("order")
                         .setCardinality(PropertyConfig.CARDINALITY_REQUIRED)
@@ -171,8 +171,9 @@ public class AppSearchHelper {
             catDocuments.add(catDoc);
         }
 
-        List<GenericDocument> documents = new ArrayList<>();
-        Set<String> indexedCombinations = new LinkedHashSet<>();
+        Map<String, GenericDocument.Builder<?>> docBuilders = new LinkedHashMap<>();
+        Map<String, Set<String>> itemCategories = new LinkedHashMap<>();
+
         for (Icon section : sections) {
             String category = section.getTitle();
             for (Icon icon : section.getIcons()) {
@@ -181,20 +182,37 @@ public class AppSearchHelper {
 
                 String title = icon.getTitle() != null ? icon.getTitle() : "";
                 String combinationKey = drawableName + "|" + title;
-                if (!indexedCombinations.add(combinationKey)) continue;
 
-                String docId = combinationKey;
+                Set<String> catSet = itemCategories.get(combinationKey);
+                if (catSet == null) {
+                    catSet = new LinkedHashSet<>();
+                    itemCategories.put(combinationKey, catSet);
+                }
+                if (category != null && !category.isEmpty()) {
+                    catSet.add(category);
+                }
 
-                GenericDocument.Builder<?> docBuilder = new GenericDocument.Builder<>("icons", docId, "Icon")
-                        .setPropertyString("drawableName", drawableName)
-                        .setPropertyString("title", title)
-                        .setPropertyString("customName", icon.getCustomName() != null ? icon.getCustomName() : "")
-                        .setPropertyLong("resId", icon.getRes())
-                        .setPropertyString("category", category != null ? category : "")
-                        .setPropertyString("tags", icon.getTags().toArray(new String[0]));
-
-                documents.add(docBuilder.build());
+                if (!docBuilders.containsKey(combinationKey)) {
+                    GenericDocument.Builder<?> docBuilder = new GenericDocument.Builder<>("icons", combinationKey, "Icon")
+                            .setPropertyString("drawableName", drawableName)
+                            .setPropertyString("title", title)
+                            .setPropertyString("customName", icon.getCustomName() != null ? icon.getCustomName() : "")
+                            .setPropertyLong("resId", icon.getRes())
+                            .setPropertyString("tags", icon.getTags().toArray(new String[0]));
+                    docBuilders.put(combinationKey, docBuilder);
+                }
             }
+        }
+
+        List<GenericDocument> documents = new ArrayList<>();
+        for (Map.Entry<String, GenericDocument.Builder<?>> entry : docBuilders.entrySet()) {
+            String key = entry.getKey();
+            GenericDocument.Builder<?> builder = entry.getValue();
+            Set<String> catSet = itemCategories.get(key);
+            if (catSet != null && !catSet.isEmpty()) {
+                builder.setPropertyString("categories", catSet.toArray(new String[0]));
+            }
+            documents.add(builder.build());
         }
 
         PutDocumentsRequest catPutRequest = new PutDocumentsRequest.Builder()

--- a/library/src/main/java/candybar/lib/helpers/AppSearchHelper.java
+++ b/library/src/main/java/candybar/lib/helpers/AppSearchHelper.java
@@ -219,14 +219,14 @@ public class AppSearchHelper {
 
         if (substring && queryText != null && !queryText.trim().isEmpty()) {
             List<Icon> allIcons = queryIcons("", false);
-            String lowerQuery = queryText.toLowerCase(Locale.ENGLISH).trim();
+            String lowerQuery = queryText.toLowerCase(Locale.getDefault()).trim();
             for (Icon icon : allIcons) {
                 boolean match = false;
-                if (icon.getTitle() != null && icon.getTitle().toLowerCase(Locale.ENGLISH).contains(lowerQuery)) {
+                if (icon.getTitle() != null && icon.getTitle().toLowerCase(Locale.getDefault()).contains(lowerQuery)) {
                     match = true;
                 } else {
                     for (String tag : icon.getTags()) {
-                        if (tag.toLowerCase(Locale.ENGLISH).contains(lowerQuery)) {
+                        if (tag.toLowerCase(Locale.getDefault()).contains(lowerQuery)) {
                             match = true;
                             break;
                         }
@@ -268,10 +268,10 @@ public class AppSearchHelper {
         }
 
         if (queryText != null && !queryText.trim().isEmpty()) {
-            String cleanQuery = queryText.trim().toLowerCase(Locale.ENGLISH);
+            String cleanQuery = queryText.trim().toLowerCase(Locale.getDefault());
             Collections.sort(results, (icon1, icon2) -> {
-                boolean exact1 = icon1.getTitle() != null && icon1.getTitle().toLowerCase(Locale.ENGLISH).equals(cleanQuery);
-                boolean exact2 = icon2.getTitle() != null && icon2.getTitle().toLowerCase(Locale.ENGLISH).equals(cleanQuery);
+                boolean exact1 = icon1.getTitle() != null && icon1.getTitle().toLowerCase(Locale.getDefault()).equals(cleanQuery);
+                boolean exact2 = icon2.getTitle() != null && icon2.getTitle().toLowerCase(Locale.getDefault()).equals(cleanQuery);
                 if (exact1 && !exact2) return -1;
                 if (!exact1 && exact2) return 1;
 

--- a/library/src/main/java/candybar/lib/helpers/AppSearchHelper.java
+++ b/library/src/main/java/candybar/lib/helpers/AppSearchHelper.java
@@ -1,0 +1,292 @@
+package candybar.lib.helpers;
+
+import android.content.Context;
+import android.util.Log;
+
+import androidx.appsearch.app.AppSearchSchema;
+import androidx.appsearch.app.AppSearchSchema.PropertyConfig;
+import androidx.appsearch.app.AppSearchSchema.LongPropertyConfig;
+import androidx.appsearch.app.AppSearchSchema.StringPropertyConfig;
+import androidx.appsearch.app.AppSearchSession;
+import androidx.appsearch.app.GenericDocument;
+import androidx.appsearch.app.PutDocumentsRequest;
+import androidx.appsearch.app.SearchResult;
+import androidx.appsearch.app.SearchResults;
+import androidx.appsearch.app.SearchSpec;
+import androidx.appsearch.app.SetSchemaRequest;
+import androidx.appsearch.localstorage.LocalStorage;
+
+import com.danimahardhika.android.helpers.core.utils.LogUtil;
+import com.google.common.util.concurrent.ListenableFuture;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import candybar.lib.items.Icon;
+
+public class AppSearchHelper {
+
+    private static final String DATABASE_NAME = "icons";
+    private static AppSearchHelper sInstance;
+
+    private final ListenableFuture<AppSearchSession> mSessionFuture;
+    private final ExecutorService mExecutor = Executors.newSingleThreadExecutor();
+    private boolean mSchemaSet = false;
+    private final Object mInitLock = new Object();
+    private boolean mInitialized = false;
+
+    public static synchronized AppSearchHelper getInstance(Context context) {
+        if (sInstance == null) {
+            sInstance = new AppSearchHelper(context.getApplicationContext());
+        }
+        return sInstance;
+    }
+
+    private AppSearchHelper(Context context) {
+        mSessionFuture = LocalStorage.createSearchSessionAsync(
+                new LocalStorage.SearchContext.Builder(context, DATABASE_NAME).build()
+        );
+    }
+
+    public void initAsync(Context context) {
+        mExecutor.execute(() -> {
+            try {
+                synchronized (mInitLock) {
+                    if (mInitialized) return;
+                    getSession();
+                    mInitialized = true;
+                    mInitLock.notifyAll();
+                }
+            } catch (Exception e) {
+                LogUtil.e("Failed to pre-initialize AppSearch: " + Log.getStackTraceString(e));
+                synchronized (mInitLock) {
+                    mInitialized = true;
+                    mInitLock.notifyAll();
+                }
+            }
+        });
+    }
+
+    public void indexIconsAsync(List<Icon> sections) {
+        mExecutor.execute(() -> {
+            try {
+                ensureInitialized();
+                clearDatabase();
+                indexIcons(sections);
+            } catch (Exception e) {
+                LogUtil.e("Failed to index icons asynchronously: " + Log.getStackTraceString(e));
+            }
+        });
+    }
+
+    public void ensureInitialized() {
+        synchronized (mInitLock) {
+            while (!mInitialized) {
+                try {
+                    mInitLock.wait();
+                } catch (InterruptedException ignored) {}
+            }
+        }
+    }
+
+    public void clearDatabase() throws Exception {
+        AppSearchSession session = getSession();
+        session.removeAsync("", new SearchSpec.Builder().build()).get();
+    }
+
+    public AppSearchSession getSession() throws Exception {
+        AppSearchSession session = mSessionFuture.get();
+        synchronized (this) {
+            if (!mSchemaSet) {
+                setupSchema(session);
+                mSchemaSet = true;
+            }
+        }
+        return session;
+    }
+
+    private void setupSchema(AppSearchSession session) throws Exception {
+        AppSearchSchema iconSchema = new AppSearchSchema.Builder("Icon")
+                .addProperty(new StringPropertyConfig.Builder("drawableName")
+                        .setCardinality(PropertyConfig.CARDINALITY_OPTIONAL)
+                        .build())
+                .addProperty(new StringPropertyConfig.Builder("title")
+                        .setCardinality(PropertyConfig.CARDINALITY_OPTIONAL)
+                        .setIndexingType(StringPropertyConfig.INDEXING_TYPE_PREFIXES)
+                        .setTokenizerType(StringPropertyConfig.TOKENIZER_TYPE_PLAIN)
+                        .build())
+                .addProperty(new StringPropertyConfig.Builder("customName")
+                        .setCardinality(PropertyConfig.CARDINALITY_OPTIONAL)
+                        .build())
+                .addProperty(new LongPropertyConfig.Builder("resId")
+                        .setCardinality(PropertyConfig.CARDINALITY_REQUIRED)
+                        .build())
+                .addProperty(new StringPropertyConfig.Builder("category")
+                        .setCardinality(PropertyConfig.CARDINALITY_OPTIONAL)
+                        .setIndexingType(StringPropertyConfig.INDEXING_TYPE_EXACT_TERMS)
+                        .setTokenizerType(StringPropertyConfig.TOKENIZER_TYPE_PLAIN)
+                        .build())
+                .addProperty(new StringPropertyConfig.Builder("tags")
+                        .setCardinality(PropertyConfig.CARDINALITY_REPEATED)
+                        .setIndexingType(StringPropertyConfig.INDEXING_TYPE_PREFIXES)
+                        .setTokenizerType(StringPropertyConfig.TOKENIZER_TYPE_PLAIN)
+                        .build())
+                .build();
+
+        AppSearchSchema categorySchema = new AppSearchSchema.Builder("Category")
+                .addProperty(new StringPropertyConfig.Builder("categoryName")
+                        .setCardinality(PropertyConfig.CARDINALITY_OPTIONAL)
+                        .build())
+                .addProperty(new LongPropertyConfig.Builder("order")
+                        .setCardinality(PropertyConfig.CARDINALITY_REQUIRED)
+                        .build())
+                .build();
+
+        SetSchemaRequest setSchemaRequest = new SetSchemaRequest.Builder()
+                .addSchemas(iconSchema, categorySchema)
+                .setForceOverride(true)
+                .build();
+
+        session.setSchemaAsync(setSchemaRequest).get();
+    }
+
+    public void indexIcons(List<Icon> sections) throws Exception {
+        AppSearchSession session = getSession();
+
+        List<GenericDocument> catDocuments = new ArrayList<>();
+        int catOrder = 0;
+        for (Icon section : sections) {
+            String category = section.getTitle();
+            if (category == null) continue;
+            GenericDocument catDoc = new GenericDocument.Builder<>("categories", category, "Category")
+                    .setPropertyString("categoryName", category)
+                    .setPropertyLong("order", catOrder++)
+                    .build();
+            catDocuments.add(catDoc);
+        }
+
+        List<GenericDocument> documents = new ArrayList<>();
+        Set<String> indexedCombinations = new LinkedHashSet<>();
+        for (Icon section : sections) {
+            String category = section.getTitle();
+            for (Icon icon : section.getIcons()) {
+                String drawableName = icon.getDrawableName();
+                if (drawableName == null) continue;
+
+                String title = icon.getTitle() != null ? icon.getTitle() : "";
+                String combinationKey = drawableName + "|" + title;
+                if (!indexedCombinations.add(combinationKey)) continue;
+
+                String docId = combinationKey;
+
+                GenericDocument.Builder<?> docBuilder = new GenericDocument.Builder<>("icons", docId, "Icon")
+                        .setPropertyString("drawableName", drawableName)
+                        .setPropertyString("title", title)
+                        .setPropertyString("customName", icon.getCustomName() != null ? icon.getCustomName() : "")
+                        .setPropertyLong("resId", icon.getRes())
+                        .setPropertyString("category", category != null ? category : "")
+                        .setPropertyString("tags", icon.getTags().toArray(new String[0]));
+
+                documents.add(docBuilder.build());
+            }
+        }
+
+        PutDocumentsRequest catPutRequest = new PutDocumentsRequest.Builder()
+                .addGenericDocuments(catDocuments)
+                .build();
+        session.putAsync(catPutRequest).get();
+
+        int batchSize = 500;
+        for (int i = 0; i < documents.size(); i += batchSize) {
+            List<GenericDocument> batch = documents.subList(i, Math.min(i + batchSize, documents.size()));
+            PutDocumentsRequest putRequest = new PutDocumentsRequest.Builder()
+                    .addGenericDocuments(batch)
+                    .build();
+            session.putAsync(putRequest).get();
+        }
+        LogUtil.d("AppSearch successfully indexed " + catDocuments.size() + " categories and " + documents.size() + " icon entries");
+    }
+
+    public List<Icon> queryIcons(String queryText, boolean substring) throws Exception {
+        AppSearchSession session = getSession();
+        List<Icon> results = new ArrayList<>();
+
+        if (substring && queryText != null && !queryText.trim().isEmpty()) {
+            List<Icon> allIcons = queryIcons("", false);
+            String lowerQuery = queryText.toLowerCase(Locale.ENGLISH).trim();
+            for (Icon icon : allIcons) {
+                boolean match = false;
+                if (icon.getTitle() != null && icon.getTitle().toLowerCase(Locale.ENGLISH).contains(lowerQuery)) {
+                    match = true;
+                } else {
+                    for (String tag : icon.getTags()) {
+                        if (tag.toLowerCase(Locale.ENGLISH).contains(lowerQuery)) {
+                            match = true;
+                            break;
+                        }
+                    }
+                }
+                if (match) {
+                    results.add(icon);
+                }
+            }
+        } else {
+            SearchSpec searchSpec = new SearchSpec.Builder()
+                    .setResultCountPerPage(10000)
+                    .setTermMatch(SearchSpec.TERM_MATCH_PREFIX)
+                    .build();
+
+            try (SearchResults searchResults = session.search(queryText != null ? queryText.trim() : "", searchSpec)) {
+                List<SearchResult> page = searchResults.getNextPageAsync().get();
+                while (!page.isEmpty()) {
+                    for (SearchResult row : page) {
+                        GenericDocument doc = row.getGenericDocument();
+                        String drawableName = doc.getPropertyString("drawableName");
+                        String title = doc.getPropertyString("title");
+                        String customName = doc.getPropertyString("customName");
+                        int resId = (int) doc.getPropertyLong("resId");
+                        String[] tags = doc.getPropertyStringArray("tags");
+
+                        Icon icon = new Icon(drawableName, customName, resId);
+                        icon.setTitle(title);
+                        if (tags != null) {
+                            Set<String> tagSet = new LinkedHashSet<>();
+                            Collections.addAll(tagSet, tags);
+                            icon.setTags(tagSet);
+                        }
+                        results.add(icon);
+                    }
+                    page = searchResults.getNextPageAsync().get();
+                }
+            }
+        }
+
+        if (queryText != null && !queryText.trim().isEmpty()) {
+            String cleanQuery = queryText.trim().toLowerCase(Locale.ENGLISH);
+            Collections.sort(results, (icon1, icon2) -> {
+                boolean exact1 = icon1.getTitle() != null && icon1.getTitle().toLowerCase(Locale.ENGLISH).equals(cleanQuery);
+                boolean exact2 = icon2.getTitle() != null && icon2.getTitle().toLowerCase(Locale.ENGLISH).equals(cleanQuery);
+                if (exact1 && !exact2) return -1;
+                if (!exact1 && exact2) return 1;
+
+                String title1 = icon1.getTitle() != null ? icon1.getTitle() : "";
+                String title2 = icon2.getTitle() != null ? icon2.getTitle() : "";
+                return title1.compareToIgnoreCase(title2);
+            });
+        } else {
+            Collections.sort(results, (icon1, icon2) -> {
+                String title1 = icon1.getTitle() != null ? icon1.getTitle() : "";
+                String title2 = icon2.getTitle() != null ? icon2.getTitle() : "";
+                return title1.compareToIgnoreCase(title2);
+            });
+        }
+
+        return results;
+    }
+}

--- a/library/src/main/java/candybar/lib/helpers/IconsHelper.java
+++ b/library/src/main/java/candybar/lib/helpers/IconsHelper.java
@@ -2,6 +2,7 @@ package candybar.lib.helpers;
 
 import static com.danimahardhika.android.helpers.core.FileHelper.getUriFromFile;
 
+import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
@@ -24,14 +25,18 @@ import com.bumptech.glide.request.target.Target;
 import com.danimahardhika.android.helpers.core.utils.LogUtil;
 
 import org.xmlpull.v1.XmlPullParser;
+import org.xmlpull.v1.XmlPullParserException;
 
 import java.io.File;
 import java.io.FileOutputStream;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import candybar.lib.R;
@@ -69,6 +74,7 @@ public class IconsHelper {
                 List<Icon> icons = section.getIcons();
 
                 computeTitles(context, icons);
+                computeTags(context, icons);
 
                 if (sortIcons && context.getResources().getBoolean(R.bool.enable_icons_sort)) {
                     Collections.sort(icons, Icon.TitleComparator);
@@ -190,6 +196,53 @@ public class IconsHelper {
             capitalizeWord.append(first.toUpperCase()).append(afterfirst).append(" ");
         }
         return capitalizeWord.toString().trim();
+    }
+
+    public static void computeTags(@NonNull Context context, List<Icon> icons) {
+        if (!context.getResources().getBoolean(R.bool.enable_icons_tag_search))
+            return; // Tagging not enabled, nothing to do
+
+        String tagResourceFileName = context.getResources().getString(R.string.icon_tags_xml);
+        @SuppressLint("DiscouragedApi") int tagResourceId = context.getResources().getIdentifier(tagResourceFileName, "xml", context.getPackageName());
+        if (tagResourceId == 0)
+            return; // Resource doesn't exist, nothing to do
+
+        Map<String, Set<String>> tags = new HashMap<>();
+
+        try {
+            XmlResourceParser parser = context.getResources().getXml(tagResourceId);
+            int eventType = parser.getEventType();
+            String currentDrawable = null;
+            Set<String> currentTags = Collections.emptySet();
+            while (eventType != XmlPullParser.END_DOCUMENT) {
+                if (eventType == XmlPullParser.START_TAG) {
+                    String name = parser.getName();
+                    if ("icon".equals(name)) {
+                        currentDrawable = context.getResources().getResourceEntryName(parser.getAttributeResourceValue(null, "drawable", 0));
+                        currentTags = new LinkedHashSet<>();
+                    } else if ("tag".equals(name) && currentDrawable != null) {
+                        String value = context.getResources().getString(parser.getAttributeResourceValue(null, "value", 0));
+                        if (!value.isEmpty()) {
+                            currentTags.add(value);
+                        }
+                    }
+                } else if (eventType == XmlPullParser.END_TAG && "icon".equals(parser.getName())) {
+                    if (currentDrawable != null && !currentTags.isEmpty()) {
+                        tags.put(currentDrawable, currentTags);
+                    }
+                    currentDrawable = null;
+                    currentTags = Collections.emptySet();
+                }
+                eventType = parser.next();
+            }
+        } catch (XmlPullParserException | IOException ignored) {}
+
+        for (Icon icon : icons) {
+            Set<String> iconTags = tags.get(icon.getDrawableName());
+            if (iconTags != null && !iconTags.isEmpty()) {
+                icon.setTags(iconTags);
+            }
+        }
     }
 
     public static void selectIcon(@NonNull Context context, int action, Icon icon) {

--- a/library/src/main/java/candybar/lib/helpers/IconsHelper.java
+++ b/library/src/main/java/candybar/lib/helpers/IconsHelper.java
@@ -7,6 +7,7 @@ import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.content.res.XmlResourceParser;
+import android.database.Cursor;
 import android.graphics.Bitmap;
 import android.graphics.drawable.Drawable;
 import android.net.Uri;
@@ -87,7 +88,63 @@ public class IconsHelper {
                 CandyBarMainActivity.sSections.add(new Icon(
                         CandyBarApplication.getConfiguration().getTabAllIconsTitle(), icons));
             }
+
+            // Index the fully loaded and computed sections into AppSearch in the background
+            AppSearchHelper.getInstance(context).indexIconsAsync(CandyBarMainActivity.sSections);
         }
+    }
+
+    private record CursorIcon(Icon icon, String category) { }
+
+    private static List<CursorIcon> parseIconsCursor(Cursor cursor) {
+        List<CursorIcon> list = new ArrayList<>();
+        if (cursor == null) return list;
+        try (cursor) {
+            int drawableNameIndex = cursor.getColumnIndexOrThrow("drawable_name");
+            int titleIndex = cursor.getColumnIndexOrThrow("title");
+            int customNameIndex = cursor.getColumnIndexOrThrow("custom_name");
+            int resIdIndex = cursor.getColumnIndexOrThrow("res_id");
+            int categoryIndex = cursor.getColumnIndexOrThrow("category");
+            int tagsIndex = cursor.getColumnIndexOrThrow("tags");
+
+            while (cursor.moveToNext()) {
+                String drawableName = cursor.getString(drawableNameIndex);
+                String title = cursor.getString(titleIndex);
+                String customName = cursor.getString(customNameIndex);
+                int resId = cursor.getInt(resIdIndex);
+                String category = cursor.getString(categoryIndex);
+                String tagsString = cursor.getString(tagsIndex);
+
+                Icon icon = new Icon(drawableName, customName, resId);
+                icon.setTitle(title);
+                if (tagsString != null && !tagsString.isEmpty()) {
+                    Set<String> tagsSet = new LinkedHashSet<>();
+                    Collections.addAll(tagsSet, tagsString.split(","));
+                    icon.setTags(tagsSet);
+                }
+                list.add(new CursorIcon(icon, category));
+            }
+        }
+        return list;
+    }
+
+    @NonNull
+    public static List<Icon> search(@NonNull Context context, @NonNull String query, boolean substring) {
+        Uri uri = Uri.parse("content://" + context.getPackageName() + ".icons/icons")
+                .buildUpon()
+                .appendQueryParameter("query", query)
+                .appendQueryParameter("substring", String.valueOf(substring))
+                .build();
+
+        Cursor cursor = context.getContentResolver().query(uri, null, null, null, null);
+        List<Icon> icons = new ArrayList<>();
+        if (cursor != null) {
+            List<CursorIcon> cursorIcons = parseIconsCursor(cursor);
+            for (CursorIcon item : cursorIcons) {
+                icons.add(item.icon);
+            }
+        }
+        return icons;
     }
 
     @NonNull
@@ -135,7 +192,7 @@ public class IconsHelper {
         return sections;
     }
 
-    public static List<Icon> getTabAllIcons() {
+    private static List<Icon> getTabAllIcons() {
         Set<Icon> iconSet = new HashSet<>();
         String[] categories = CandyBarApplication.getConfiguration().getCategoryForTabAllIcons();
 
@@ -158,7 +215,7 @@ public class IconsHelper {
         return icons;
     }
 
-    public static void computeTitles(@NonNull Context context, List<Icon> icons) {
+    private static void computeTitles(@NonNull Context context, List<Icon> icons) {
         final boolean iconReplacer = context.getResources().getBoolean(R.bool.enable_icon_name_replacer);
         for (Icon icon : icons) {
             if (icon.getTitle() != null) {
@@ -173,7 +230,7 @@ public class IconsHelper {
         }
     }
 
-    public static String replaceName(@NonNull Context context, boolean iconReplacer, String name) {
+    private static String replaceName(@NonNull Context context, boolean iconReplacer, String name) {
         if (iconReplacer) {
             String[] replacer = context.getResources().getStringArray(R.array.icon_name_replacer);
             for (String replace : replacer) {
@@ -187,7 +244,7 @@ public class IconsHelper {
         return capitalizeWord(name);
     }
 
-    public static String capitalizeWord(String str) {
+    private static String capitalizeWord(String str) {
         String[] words = str.split("\\s");
         StringBuilder capitalizeWord = new StringBuilder();
         for (String w : words) {
@@ -198,7 +255,7 @@ public class IconsHelper {
         return capitalizeWord.toString().trim();
     }
 
-    public static void computeTags(@NonNull Context context, List<Icon> icons) {
+    private static void computeTags(@NonNull Context context, List<Icon> icons) {
         if (!context.getResources().getBoolean(R.bool.enable_icons_tag_search))
             return; // Tagging not enabled, nothing to do
 

--- a/library/src/main/java/candybar/lib/items/Icon.java
+++ b/library/src/main/java/candybar/lib/items/Icon.java
@@ -2,8 +2,10 @@ package candybar.lib.items;
 
 import androidx.annotation.NonNull;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 
 import candybar.lib.utils.AlphanumComparator;
 
@@ -30,6 +32,7 @@ public class Icon {
     private String mDrawableName;
     private String mCustomName;
     private String mTitle;
+    private Set<String> mTags;
     private int mRes;
     private String mPackageName;
     private List<Icon> mIcons;
@@ -88,6 +91,10 @@ public class Icon {
     public void setPackageName(String packageName) {
         mPackageName = packageName;
     }
+
+    public void setTags(Set<String> tags) { mTags = tags; }
+
+    public Set<String> getTags() { return (mTags != null) ? mTags : Collections.emptySet(); }
 
     @Override
     public boolean equals(Object object) {

--- a/library/src/main/java/candybar/lib/providers/IconsProvider.java
+++ b/library/src/main/java/candybar/lib/providers/IconsProvider.java
@@ -1,0 +1,248 @@
+package candybar.lib.providers;
+
+import android.content.ContentProvider;
+import android.content.ContentValues;
+import android.content.UriMatcher;
+import android.database.Cursor;
+import android.database.MatrixCursor;
+import android.net.Uri;
+import android.text.TextUtils;
+import android.util.Log;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.appsearch.app.AppSearchSession;
+import androidx.appsearch.app.GenericDocument;
+import androidx.appsearch.app.SearchResult;
+import androidx.appsearch.app.SearchResults;
+import androidx.appsearch.app.SearchSpec;
+
+import com.danimahardhika.android.helpers.core.utils.LogUtil;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+
+import candybar.lib.helpers.AppSearchHelper;
+
+public class IconsProvider extends ContentProvider {
+
+    private static final int ICONS = 1;
+    private static final int CATEGORIES = 2;
+    private static UriMatcher sUriMatcher;
+
+    private AppSearchHelper mAppSearchHelper;
+
+    private synchronized UriMatcher getUriMatcher() {
+        if (sUriMatcher == null) {
+            sUriMatcher = new UriMatcher(UriMatcher.NO_MATCH);
+            String authority = getContext().getPackageName() + ".icons";
+            sUriMatcher.addURI(authority, "icons", ICONS);
+            sUriMatcher.addURI(authority, "categories", CATEGORIES);
+        }
+        return sUriMatcher;
+    }
+
+    @Override
+    public boolean onCreate() {
+        mAppSearchHelper = AppSearchHelper.getInstance(getContext());
+        return true;
+    }
+
+    @Nullable
+    @Override
+    public Cursor query(@NonNull Uri uri, @Nullable String[] projection, @Nullable String selection,
+                        @Nullable String[] selectionArgs, @Nullable String sortOrder) {
+        int match = getUriMatcher().match(uri);
+        if (match == UriMatcher.NO_MATCH) {
+            throw new IllegalArgumentException("Unknown URI: " + uri);
+        }
+
+        mAppSearchHelper.ensureInitialized();
+
+        if (match == ICONS) {
+            String queryText = uri.getQueryParameter("query");
+            boolean substring = Boolean.parseBoolean(uri.getQueryParameter("substring"));
+
+            String[] cols = projection != null ? projection : new String[] {
+                "drawable_name", "title", "custom_name", "res_id", "category", "tags"
+            };
+
+            MatrixCursor cursor = new MatrixCursor(cols);
+            try {
+                AppSearchSession session = mAppSearchHelper.getSession();
+                List<SearchResult> allResults = new ArrayList<>();
+
+                SearchSpec.Builder specBuilder = new SearchSpec.Builder()
+                        .setResultCountPerPage(10000)
+                        .addFilterSchemas("Icon");
+
+                specBuilder.setTermMatch(SearchSpec.TERM_MATCH_PREFIX);
+
+                String appsearchQuery = (substring || queryText == null) ? "" : queryText.trim();
+
+                try (SearchResults searchResults = session.search(appsearchQuery, specBuilder.build())) {
+                    List<SearchResult> page = searchResults.getNextPageAsync().get();
+                    while (!page.isEmpty()) {
+                        allResults.addAll(page);
+                        page = searchResults.getNextPageAsync().get();
+                    }
+                }
+
+                List<GenericDocument> matchedDocs = new ArrayList<>();
+                if (substring && queryText != null && !queryText.trim().isEmpty()) {
+                    String cleanQuery = queryText.toLowerCase(Locale.ENGLISH).trim();
+                    for (SearchResult row : allResults) {
+                        GenericDocument doc = row.getGenericDocument();
+                        String title = doc.getPropertyString("title");
+                        String[] tags = doc.getPropertyStringArray("tags");
+                        boolean matchFound = false;
+                        if (title != null && title.toLowerCase(Locale.ENGLISH).contains(cleanQuery)) {
+                            matchFound = true;
+                        } else if (tags != null) {
+                            for (String tag : tags) {
+                                if (tag.toLowerCase(Locale.ENGLISH).contains(cleanQuery)) {
+                                    matchFound = true;
+                                    break;
+                                }
+                            }
+                        }
+                        if (matchFound) {
+                            matchedDocs.add(doc);
+                        }
+                    }
+                } else {
+                    for (SearchResult row : allResults) {
+                        matchedDocs.add(row.getGenericDocument());
+                    }
+                }
+
+                if (queryText != null && !queryText.trim().isEmpty()) {
+                    String cleanQuery = queryText.toLowerCase(Locale.ENGLISH).trim();
+                    Collections.sort(matchedDocs, (doc1, doc2) -> {
+                        String t1 = doc1.getPropertyString("title");
+                        String t2 = doc2.getPropertyString("title");
+                        boolean exact1 = t1 != null && t1.toLowerCase(Locale.ENGLISH).equals(cleanQuery);
+                        boolean exact2 = t2 != null && t2.toLowerCase(Locale.ENGLISH).equals(cleanQuery);
+                        if (exact1 && !exact2) return -1;
+                        if (!exact1 && exact2) return 1;
+
+                        String title1 = t1 != null ? t1 : "";
+                        String title2 = t2 != null ? t2 : "";
+                        return title1.compareToIgnoreCase(title2);
+                    });
+                } else {
+                    Collections.sort(matchedDocs, (doc1, doc2) -> {
+                        String title1 = doc1.getPropertyString("title");
+                        String title2 = doc2.getPropertyString("title");
+                        String t1 = title1 != null ? title1 : "";
+                        String t2 = title2 != null ? title2 : "";
+                        return t1.compareToIgnoreCase(t2);
+                    });
+                }
+
+                for (GenericDocument doc : matchedDocs) {
+                    MatrixCursor.RowBuilder row = cursor.newRow();
+                    for (String col : cols) {
+                        if ("drawable_name".equals(col)) {
+                            row.add(doc.getPropertyString("drawableName"));
+                        } else if ("title".equals(col)) {
+                            row.add(doc.getPropertyString("title"));
+                        } else if ("custom_name".equals(col)) {
+                            row.add(doc.getPropertyString("customName"));
+                        } else if ("res_id".equals(col) || "_id".equals(col)) {
+                            row.add((int) doc.getPropertyLong("resId"));
+                        } else if ("category".equals(col)) {
+                            row.add(doc.getPropertyString("category"));
+                        } else if ("tags".equals(col)) {
+                            String[] tags = doc.getPropertyStringArray("tags");
+                            row.add(tags != null ? TextUtils.join(",", tags) : "");
+                        } else {
+                            row.add(null);
+                        }
+                    }
+                }
+            } catch (Exception e) {
+                LogUtil.e("IconsProvider query failed: " + Log.getStackTraceString(e));
+            }
+            return cursor;
+        } else if (match == CATEGORIES) {
+            String[] cols = projection != null ? projection : new String[] { "_id", "category_name" };
+            MatrixCursor cursor = new MatrixCursor(cols);
+            try {
+                AppSearchSession session = mAppSearchHelper.getSession();
+                SearchSpec spec = new SearchSpec.Builder()
+                        .setResultCountPerPage(10000)
+                        .setTermMatch(SearchSpec.TERM_MATCH_PREFIX)
+                        .addFilterSchemas("Category")
+                        .build();
+
+                List<GenericDocument> catDocs = new ArrayList<>();
+                try (SearchResults searchResults = session.search("", spec)) {
+                    List<SearchResult> page = searchResults.getNextPageAsync().get();
+                    while (!page.isEmpty()) {
+                        for (SearchResult row : page) {
+                            catDocs.add(row.getGenericDocument());
+                        }
+                        page = searchResults.getNextPageAsync().get();
+                    }
+                }
+
+                Collections.sort(catDocs, (doc1, doc2) -> {
+                    long order1 = doc1.getPropertyLong("order");
+                    long order2 = doc2.getPropertyLong("order");
+                    return Long.compare(order1, order2);
+                });
+
+                int id = 1;
+                for (GenericDocument doc : catDocs) {
+                    String category = doc.getPropertyString("categoryName");
+                    MatrixCursor.RowBuilder row = cursor.newRow();
+                    for (String col : cols) {
+                        if ("category_name".equals(col)) {
+                            row.add(category);
+                        } else if ("_id".equals(col)) {
+                            row.add(id++);
+                        } else {
+                            row.add(null);
+                        }
+                    }
+                }
+            } catch (Exception e) {
+                LogUtil.e("IconsProvider categories query failed: " + Log.getStackTraceString(e));
+            }
+            return cursor;
+        }
+
+        return null;
+    }
+
+    @Nullable
+    @Override
+    public String getType(@NonNull Uri uri) {
+        int match = getUriMatcher().match(uri);
+        if (match == ICONS) {
+            return "vnd.android.cursor.dir/vnd.icons";
+        } else if (match == CATEGORIES) {
+            return "vnd.android.cursor.dir/vnd.categories";
+        }
+        return null;
+    }
+
+    @Nullable
+    @Override
+    public Uri insert(@NonNull Uri uri, @Nullable ContentValues values) {
+        throw new UnsupportedOperationException("Insert not supported");
+    }
+
+    @Override
+    public int delete(@NonNull Uri uri, @Nullable String selection, @Nullable String[] selectionArgs) {
+        throw new UnsupportedOperationException("Delete not supported");
+    }
+
+    @Override
+    public int update(@NonNull Uri uri, @Nullable ContentValues values, @Nullable String selection, @Nullable String[] selectionArgs) {
+        throw new UnsupportedOperationException("Update not supported");
+    }
+}

--- a/library/src/main/java/candybar/lib/providers/IconsProvider.java
+++ b/library/src/main/java/candybar/lib/providers/IconsProvider.java
@@ -92,17 +92,17 @@ public class IconsProvider extends ContentProvider {
 
                 List<GenericDocument> matchedDocs = new ArrayList<>();
                 if (substring && queryText != null && !queryText.trim().isEmpty()) {
-                    String cleanQuery = queryText.toLowerCase(Locale.ENGLISH).trim();
+                    String cleanQuery = queryText.toLowerCase(Locale.getDefault()).trim();
                     for (SearchResult row : allResults) {
                         GenericDocument doc = row.getGenericDocument();
                         String title = doc.getPropertyString("title");
                         String[] tags = doc.getPropertyStringArray("tags");
                         boolean matchFound = false;
-                        if (title != null && title.toLowerCase(Locale.ENGLISH).contains(cleanQuery)) {
+                        if (title != null && title.toLowerCase(Locale.getDefault()).contains(cleanQuery)) {
                             matchFound = true;
                         } else if (tags != null) {
                             for (String tag : tags) {
-                                if (tag.toLowerCase(Locale.ENGLISH).contains(cleanQuery)) {
+                                if (tag.toLowerCase(Locale.getDefault()).contains(cleanQuery)) {
                                     matchFound = true;
                                     break;
                                 }
@@ -119,12 +119,12 @@ public class IconsProvider extends ContentProvider {
                 }
 
                 if (queryText != null && !queryText.trim().isEmpty()) {
-                    String cleanQuery = queryText.toLowerCase(Locale.ENGLISH).trim();
+                    String cleanQuery = queryText.toLowerCase(Locale.getDefault()).trim();
                     Collections.sort(matchedDocs, (doc1, doc2) -> {
                         String t1 = doc1.getPropertyString("title");
                         String t2 = doc2.getPropertyString("title");
-                        boolean exact1 = t1 != null && t1.toLowerCase(Locale.ENGLISH).equals(cleanQuery);
-                        boolean exact2 = t2 != null && t2.toLowerCase(Locale.ENGLISH).equals(cleanQuery);
+                        boolean exact1 = t1 != null && t1.toLowerCase(Locale.getDefault()).equals(cleanQuery);
+                        boolean exact2 = t2 != null && t2.toLowerCase(Locale.getDefault()).equals(cleanQuery);
                         if (exact1 && !exact2) return -1;
                         if (!exact1 && exact2) return 1;
 

--- a/library/src/main/java/candybar/lib/providers/IconsProvider.java
+++ b/library/src/main/java/candybar/lib/providers/IconsProvider.java
@@ -63,6 +63,7 @@ public class IconsProvider extends ContentProvider {
 
         if (match == ICONS) {
             String queryText = uri.getQueryParameter("query");
+            String categoryParam = uri.getQueryParameter("category");
             boolean substring = Boolean.parseBoolean(uri.getQueryParameter("substring"));
 
             String[] cols = projection != null ? projection : new String[] {
@@ -118,6 +119,23 @@ public class IconsProvider extends ContentProvider {
                     }
                 }
 
+                if (categoryParam != null && !categoryParam.trim().isEmpty()) {
+                    String targetCategory = categoryParam.trim();
+                    List<GenericDocument> filteredByCat = new ArrayList<>();
+                    for (GenericDocument doc : matchedDocs) {
+                        String[] catArray = doc.getPropertyStringArray("categories");
+                        if (catArray != null) {
+                            for (String c : catArray) {
+                                if (targetCategory.equalsIgnoreCase(c)) {
+                                    filteredByCat.add(doc);
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                    matchedDocs = filteredByCat;
+                }
+
                 if (queryText != null && !queryText.trim().isEmpty()) {
                     String cleanQuery = queryText.toLowerCase(Locale.getDefault()).trim();
                     Collections.sort(matchedDocs, (doc1, doc2) -> {
@@ -153,8 +171,9 @@ public class IconsProvider extends ContentProvider {
                             row.add(doc.getPropertyString("customName"));
                         } else if ("res_id".equals(col) || "_id".equals(col)) {
                             row.add((int) doc.getPropertyLong("resId"));
-                        } else if ("category".equals(col)) {
-                            row.add(doc.getPropertyString("category"));
+                        } else if ("category".equals(col) || "categories".equals(col)) {
+                            String[] cats = doc.getPropertyStringArray("categories");
+                            row.add(cats != null ? TextUtils.join(",", cats) : "");
                         } else if ("tags".equals(col)) {
                             String[] tags = doc.getPropertyStringArray("tags");
                             row.add(tags != null ? TextUtils.join(",", tags) : "");

--- a/library/src/main/res/values/dashboard_configurations.xml
+++ b/library/src/main/res/values/dashboard_configurations.xml
@@ -148,6 +148,15 @@
     <bool name="enable_icons_tag_search">false</bool>
     <string name="icon_tags_xml">icon_tags</string>
 
+    <!-- Enable/disable icon substring search
+        KNOW THE IMPLICATIONS: The search index is optimized for prefix search. Lookup is usually
+        in the range of 1.5ms, full search round trip is 3-7ms when this value is `false`.
+        If set to `true`, all icons will be loaded and compared against the query. Latency for this
+        can reach 100ms or more depending on icon pack size, which can be a visible delay in the UI.
+
+        For apps with names like "My Verizon", consider adding a tag "Verizon" -->
+    <bool name="enable_icons_substring_search">false</bool>
+
     <!-- Shows icon's name below the icon, in "Icons" section -->
     <bool name="show_icon_name">true</bool>
 

--- a/library/src/main/res/values/dashboard_configurations.xml
+++ b/library/src/main/res/values/dashboard_configurations.xml
@@ -142,6 +142,12 @@
         Disabling this will improve performance and icons will load faster (because there is no sorting to do) -->
     <bool name="enable_icons_sort">true</bool>
 
+    <!-- Enable/disable icon tags
+        Enabling this will read tags from res/xml/icon_tags.xml which allows to add tags to icons,
+        so they have more chances to show up in search for users -->
+    <bool name="enable_icons_tag_search">false</bool>
+    <string name="icon_tags_xml">icon_tags</string>
+
     <!-- Shows icon's name below the icon, in "Icons" section -->
     <bool name="show_icon_name">true</bool>
 


### PR DESCRIPTION
This commit introduces a new XML file `icon_tags.xml` that contains a mapping from drawable to a list of tags. The tags are translatable, so users searching in their native language get a better chance of matching an icon rather than just searching by app title.

The feature is behind a feature flag `enable_icons_tag_search` which is `false` by default, so devs need to opt-in explicitly to make use of the feature.

It would have been easier to store tags in `drawables.xml` directly but there is reason to believe that some launchers don't cope well with unknown xml tag names. So this feature is a plugin by design.

### Open Questions
- [ ] Tags perform "exact match" if query is shorter than 2 characters, so we don't get all tags with the letter "f", for example. Should this threshold be configurable? Is there a use case where matching on two letters is bad?
- [ ] Does this raise performance problems for large apps? Especially as this adds a full loop on all the icons in the section.
- [ ] How can we make this consumable by a launcher's own icon search feature without repeating the entire XML parsing process? Perhaps via an explicit `ContentProvider`? Probably out of scope for this PR but still potentially useful as we could index icons, names and tags via `AppSearch` (https://developer.android.com/jetpack/androidx/releases/appsearch)

Refs #224 