### PR TITLE
Remove material-dialogs dependency 

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,14 +8,14 @@ android {
             storeFile file('candybar.jks')
             storePassword 'candybar'
 
-            v1SigningEnabled true
-            v2SigningEnabled true
+            v1SigningEnabled = true
+            v2SigningEnabled = true
         }
     }
 
     compileSdk = rootProject.ext.CompileSdk
 
-    namespace 'com.candybar.dev'
+    namespace = 'com.candybar.dev'
 
     defaultConfig {
         applicationId 'com.candybar.dev'
@@ -38,8 +38,8 @@ android {
 
     buildTypes {
         release {
-            signingConfig signingConfigs.release
-            minifyEnabled true
+            signingConfig = signingConfigs.release
+            minifyEnabled = true
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
@@ -49,7 +49,7 @@ android {
     }
 
     lint {
-        abortOnError false
+        abortOnError = false
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -26,8 +26,8 @@ allprojects {
         VersionName = "$major.$minor.$patch"
 
         MinSdk = 21
-        TargetSdk = 36
-        CompileSdk = 36
+        TargetSdk = 37
+        CompileSdk = 37
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:9.2.1'
+        classpath 'com.android.tools.build:gradle:9.3.1'
     }
 }
 
@@ -13,8 +13,8 @@ allprojects {
     repositories {
         mavenCentral()
         google()
-        maven { url 'https://jitpack.io' }
-        maven { url 'https://maven.google.com' }
+        maven { url = 'https://jitpack.io' }
+        maven { url = 'https://maven.google.com' }
     }
 
     rootProject.ext {

--- a/extLibs/PreLollipopTransitions/build.gradle
+++ b/extLibs/PreLollipopTransitions/build.gradle
@@ -71,5 +71,5 @@ java {
 }
 
 dependencies {
-    implementation 'androidx.appcompat:appcompat:1.8.0'
+    implementation 'androidx.appcompat:appcompat:1.7.0' // higher versions don't support targetSDK 21 anymore
 }

--- a/extLibs/PreLollipopTransitions/build.gradle
+++ b/extLibs/PreLollipopTransitions/build.gradle
@@ -71,5 +71,5 @@ java {
 }
 
 dependencies {
-    implementation 'androidx.appcompat:appcompat:1.7.0' // higher versions don't support targetSDK 21 anymore
+    implementation 'androidx.appcompat:appcompat:1.7.0' // higher versions don't support MinSdk 21 anymore
 }

--- a/extLibs/PreLollipopTransitions/build.gradle
+++ b/extLibs/PreLollipopTransitions/build.gradle
@@ -37,7 +37,7 @@ publishing {
 android {
     compileSdk = rootProject.ext.CompileSdk
 
-    namespace 'com.kogitune.activity_transition'
+    namespace = 'com.kogitune.activity_transition'
 
     defaultConfig {
         minSdkVersion rootProject.ext.MinSdk
@@ -45,7 +45,7 @@ android {
 
     buildTypes {
         release {
-            minifyEnabled false
+            minifyEnabled = false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
@@ -71,5 +71,5 @@ java {
 }
 
 dependencies {
-    implementation 'androidx.appcompat:appcompat:1.7.0'
+    implementation 'androidx.appcompat:appcompat:1.8.0'
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,6 @@
 # http://www.gradle.org/docs/current/userguide/build_environment.html
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-android.enableJetifier=true
 android.useAndroidX=true
 org.gradle.jvmargs=-Xms512m -Xmx2048m
 # kapt.incremental.apt=false

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,6 +6,7 @@
 # http://www.gradle.org/docs/current/userguide/build_environment.html
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
+android.enableJetifier=true
 android.useAndroidX=true
 org.gradle.jvmargs=-Xms512m -Xmx2048m
 # kapt.incremental.apt=false

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.7.0-bin.zip

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -105,7 +105,7 @@ dependencies {
     api 'dev.jahir.KustomAPI:api:6369c37'
     api 'dev.jahir.KustomAPI:preset:6369c37'
 
-    implementation 'androidx.work:work-runtime:2.11.2'
+    implementation 'androidx.work:work-runtime:2.10.5'  // 2.10.5 or higher doesn't support targetSDK 21 anymore
     implementation 'androidx.recyclerview:recyclerview:1.4.0'
     implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.2.0'
     implementation 'androidx.palette:palette:1.0.0'

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -99,17 +99,17 @@ dependencies {
     implementation project(':extLibs:PreLollipopTransitions')
 
     api 'androidx.annotation:annotation:1.10.0'
-    api 'androidx.appcompat:appcompat:1.7.0' // 1.7.0 or higher doesn't support targetSDK 21 anymore
+    api 'androidx.appcompat:appcompat:1.7.0' // higher versions don't support targetSDK 21 anymore
     api 'com.google.android.apps.muzei:muzei-api:3.4.2'
     api 'com.android.billingclient:billing:9.1.0'
     api 'dev.jahir.KustomAPI:api:6369c37'
     api 'dev.jahir.KustomAPI:preset:6369c37'
 
-    implementation 'androidx.work:work-runtime:2.10.5'  // 2.10.5 or higher doesn't support targetSDK 21 anymore
+    implementation 'androidx.work:work-runtime:2.10.5' // higher versions don't support targetSDK 21 anymore
     implementation 'androidx.recyclerview:recyclerview:1.4.0'
     implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.2.0'
     implementation 'androidx.palette:palette:1.0.0'
-    implementation 'com.google.android.material:material:1.13.0' // 1.14.0 or higher doesn't support targetSDK 21 anymore
+    implementation 'com.google.android.material:material:1.13.0' // higher versions don't support targetSDK 21 anymore
     implementation 'androidx.viewpager2:viewpager2:1.1.0'
     implementation 'com.google.android.play:review:2.0.2'
     implementation 'androidx.core:core-splashscreen:1.2.0'
@@ -117,7 +117,7 @@ dependencies {
     implementation 'com.bluelinelabs:logansquare:1.3.7'
     annotationProcessor 'com.bluelinelabs:logansquare-compiler:1.3.7'
 
-    implementation 'com.github.bumptech.glide:glide:5.0.5' // 5.0.5 or higher doesn't support targetSDK 21 anymore
+    implementation 'com.github.bumptech.glide:glide:5.0.5' // higher versions don't support targetSDK 21 anymore
     annotationProcessor 'com.github.bumptech.glide:compiler:5.0.9'
 
     implementation 'com.squareup.okhttp3:okhttp:5.4.0'

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -117,7 +117,7 @@ dependencies {
     implementation 'com.bluelinelabs:logansquare:1.3.7'
     annotationProcessor 'com.bluelinelabs:logansquare-compiler:1.3.7'
 
-    implementation 'com.github.bumptech.glide:glide:5.0.9'
+    implementation 'com.github.bumptech.glide:glide:5.0.5' // 5.0.5 or higher doesn't support targetSDK 21 anymore
     annotationProcessor 'com.github.bumptech.glide:compiler:5.0.9'
 
     implementation 'com.squareup.okhttp3:okhttp:5.4.0'

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -99,17 +99,17 @@ dependencies {
     implementation project(':extLibs:PreLollipopTransitions')
 
     api 'androidx.annotation:annotation:1.10.0'
-    api 'androidx.appcompat:appcompat:1.7.0' // higher versions don't support targetSDK 21 anymore
+    api 'androidx.appcompat:appcompat:1.7.0' // higher versions don't support MinSdk 21 anymore
     api 'com.google.android.apps.muzei:muzei-api:3.4.2'
-    api 'com.android.billingclient:billing:8.0.0' // higher versions don't support targetSDK 21 anymore
+    api 'com.android.billingclient:billing:8.0.0' // higher versions don't support MinSdk 21 anymore
     api 'dev.jahir.KustomAPI:api:6369c37'
     api 'dev.jahir.KustomAPI:preset:6369c37'
 
-    implementation 'androidx.work:work-runtime:2.10.5' // higher versions don't support targetSDK 21 anymore
+    implementation 'androidx.work:work-runtime:2.10.5' // higher versions don't support MinSdk 21 anymore
     implementation 'androidx.recyclerview:recyclerview:1.4.0'
     implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.2.0'
     implementation 'androidx.palette:palette:1.0.0'
-    implementation 'com.google.android.material:material:1.13.0' // higher versions don't support targetSDK 21 anymore
+    implementation 'com.google.android.material:material:1.13.0' // higher versions don't support MinSdk 21 anymore
     implementation 'androidx.viewpager2:viewpager2:1.1.0'
     implementation 'com.google.android.play:review:2.0.2'
     implementation 'androidx.core:core-splashscreen:1.2.0'
@@ -117,7 +117,7 @@ dependencies {
     implementation 'com.bluelinelabs:logansquare:1.3.7'
     annotationProcessor 'com.bluelinelabs:logansquare-compiler:1.3.7'
 
-    implementation 'com.github.bumptech.glide:glide:5.0.5' // higher versions don't support targetSDK 21 anymore
+    implementation 'com.github.bumptech.glide:glide:5.0.5' // higher versions don't support MinSdk 21 anymore
     annotationProcessor 'com.github.bumptech.glide:compiler:5.0.9'
 
     implementation 'com.squareup.okhttp3:okhttp:5.4.0'

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -109,7 +109,7 @@ dependencies {
     implementation 'androidx.recyclerview:recyclerview:1.4.0'
     implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.2.0'
     implementation 'androidx.palette:palette:1.0.0'
-    implementation 'com.google.android.material:material:1.14.0'
+    implementation 'com.google.android.material:material:1.13.0' // 1.14.0 or higher doesn't support targetSDK 21 anymore
     implementation 'androidx.viewpager2:viewpager2:1.1.0'
     implementation 'com.google.android.play:review:2.0.2'
     implementation 'androidx.core:core-splashscreen:1.2.0'

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -101,7 +101,7 @@ dependencies {
     api 'androidx.annotation:annotation:1.10.0'
     api 'androidx.appcompat:appcompat:1.7.0' // higher versions don't support targetSDK 21 anymore
     api 'com.google.android.apps.muzei:muzei-api:3.4.2'
-    api 'com.android.billingclient:billing:9.1.0'
+    api 'com.android.billingclient:billing:8.0.0' // higher versions don't support targetSDK 21 anymore
     api 'dev.jahir.KustomAPI:api:6369c37'
     api 'dev.jahir.KustomAPI:preset:6369c37'
 

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -99,7 +99,7 @@ dependencies {
     implementation project(':extLibs:PreLollipopTransitions')
 
     api 'androidx.annotation:annotation:1.10.0'
-    api 'androidx.appcompat:appcompat:1.8.0'
+    api 'androidx.appcompat:appcompat:1.7.0' // 1.7.0 or higher doesn't support targetSDK 21 anymore
     api 'com.google.android.apps.muzei:muzei-api:3.4.2'
     api 'com.android.billingclient:billing:9.1.0'
     api 'dev.jahir.KustomAPI:api:6369c37'

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -121,8 +121,6 @@ dependencies {
     annotationProcessor 'com.github.bumptech.glide:compiler:5.0.9'
 
     implementation 'com.squareup.okhttp3:okhttp:5.4.0'
-    implementation 'com.afollestad.material-dialogs:core:0.9.6.0'
-    implementation 'com.afollestad.material-dialogs:commons:0.9.6.0'
     implementation 'com.mikhaellopez:circularimageview:4.3.1'
     implementation 'com.github.Baseflow:PhotoView:2.3.0'
     implementation 'me.grantland:autofittextview:0.2.1'

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -121,7 +121,7 @@ dependencies {
     annotationProcessor 'com.github.bumptech.glide:compiler:5.0.9'
 
     implementation 'com.squareup.okhttp3:okhttp:5.4.0'
-    implementation 'com.afollestad.material-dialogs:core:3.3.0'
+    implementation 'com.afollestad.material-dialogs:core:0.9.6.0'
     implementation 'com.afollestad.material-dialogs:commons:0.9.6.0'
     implementation 'com.mikhaellopez:circularimageview:4.3.1'
     implementation 'com.github.Baseflow:PhotoView:2.3.0'

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -46,11 +46,11 @@ allprojects {
 android {
     compileSdk = rootProject.ext.CompileSdk
 
-    namespace 'candybar.lib'
+    namespace = 'candybar.lib'
 
     defaultConfig {
         minSdkVersion rootProject.ext.MinSdk
-        vectorDrawables.useSupportLibrary true
+        vectorDrawables.useSupportLibrary = true
         buildConfigField 'String', 'VERSION_NAME', "\"${rootProject.ext.VersionName}\""
     }
 
@@ -76,7 +76,7 @@ android {
     }
 
     lint {
-        abortOnError false
+        abortOnError = false
         disable 'MissingTranslation'
         targetSdk 36
     }
@@ -98,30 +98,30 @@ java {
 dependencies {
     implementation project(':extLibs:PreLollipopTransitions')
 
-    api 'androidx.annotation:annotation:1.9.1'
-    api 'androidx.appcompat:appcompat:1.7.1'
+    api 'androidx.annotation:annotation:1.10.0'
+    api 'androidx.appcompat:appcompat:1.8.0'
     api 'com.google.android.apps.muzei:muzei-api:3.4.2'
-    api 'com.android.billingclient:billing:8.0.0'
+    api 'com.android.billingclient:billing:9.1.0'
     api 'dev.jahir.KustomAPI:api:6369c37'
     api 'dev.jahir.KustomAPI:preset:6369c37'
 
-    implementation 'androidx.work:work-runtime:2.10.5'
+    implementation 'androidx.work:work-runtime:2.11.2'
     implementation 'androidx.recyclerview:recyclerview:1.4.0'
-    implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.1.0'
+    implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.2.0'
     implementation 'androidx.palette:palette:1.0.0'
-    implementation 'com.google.android.material:material:1.13.0'
+    implementation 'com.google.android.material:material:1.14.0'
     implementation 'androidx.viewpager2:viewpager2:1.1.0'
     implementation 'com.google.android.play:review:2.0.2'
-    implementation 'androidx.core:core-splashscreen:1.0.1'
+    implementation 'androidx.core:core-splashscreen:1.2.0'
 
     implementation 'com.bluelinelabs:logansquare:1.3.7'
     annotationProcessor 'com.bluelinelabs:logansquare-compiler:1.3.7'
 
-    implementation 'com.github.bumptech.glide:glide:5.0.5'
-    annotationProcessor 'com.github.bumptech.glide:compiler:5.0.5'
+    implementation 'com.github.bumptech.glide:glide:5.0.9'
+    annotationProcessor 'com.github.bumptech.glide:compiler:5.0.9'
 
-    implementation 'com.squareup.okhttp3:okhttp:5.2.1'
-    implementation 'com.afollestad.material-dialogs:core:0.9.6.0'
+    implementation 'com.squareup.okhttp3:okhttp:5.4.0'
+    implementation 'com.afollestad.material-dialogs:core:3.3.0'
     implementation 'com.afollestad.material-dialogs:commons:0.9.6.0'
     implementation 'com.mikhaellopez:circularimageview:4.3.1'
     implementation 'com.github.Baseflow:PhotoView:2.3.0'

--- a/library/src/main/java/candybar/lib/activities/CandyBarCrashReport.java
+++ b/library/src/main/java/candybar/lib/activities/CandyBarCrashReport.java
@@ -7,7 +7,7 @@ import android.os.Bundle;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
 
-import com.afollestad.materialdialogs.MaterialDialog;
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 import com.danimahardhika.android.helpers.core.FileHelper;
 
 import java.io.File;
@@ -57,14 +57,11 @@ public class CandyBarCrashReport extends AppCompatActivity {
             String message = getResources().getString(R.string.crash_report_message, getResources().getString(R.string.app_name));
             String emailAddress = getResources().getString(R.string.regular_request_email);
 
-            new MaterialDialog.Builder(this)
-                    .title(R.string.crash_report)
-                    .content(message)
-                    .cancelable(false)
-                    .canceledOnTouchOutside(false)
-                    .positiveText(R.string.crash_report_send)
-                    .negativeText(R.string.close)
-                    .onPositive((dialog, which) -> {
+            new MaterialAlertDialogBuilder(this)
+                    .setTitle(R.string.crash_report)
+                    .setMessage(message)
+                    .setCancelable(false)
+                    .setPositiveButton(R.string.crash_report_send, (dialog, which) -> {
                         Intent intent = new Intent(Intent.ACTION_SEND);
                         intent.setType("text/plain");
                         intent.putExtra(Intent.EXTRA_EMAIL, new String[]{emailAddress});
@@ -74,9 +71,9 @@ public class CandyBarCrashReport extends AppCompatActivity {
 
                         startActivity(Intent.createChooser(intent,
                                 getResources().getString(R.string.app_client)));
-                        dialog.dismiss();
                     })
-                    .dismissListener(dialogInterface -> finish())
+                    .setNegativeButton(R.string.close, null)
+                    .setOnDismissListener(dialogInterface -> finish())
                     .show();
         } catch (Exception e) {
             finish();

--- a/library/src/main/java/candybar/lib/activities/CandyBarMainActivity.java
+++ b/library/src/main/java/candybar/lib/activities/CandyBarMainActivity.java
@@ -43,7 +43,7 @@ import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentManager;
 import androidx.fragment.app.FragmentTransaction;
 
-import com.afollestad.materialdialogs.MaterialDialog;
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 import com.android.billingclient.api.AcknowledgePurchaseParams;
 import com.android.billingclient.api.BillingClient;
 import com.android.billingclient.api.BillingFlowParams;
@@ -96,7 +96,6 @@ import candybar.lib.helpers.LocaleHelper;
 import candybar.lib.helpers.NavigationViewHelper;
 import candybar.lib.helpers.RequestHelper;
 import candybar.lib.helpers.ThemeHelper;
-import candybar.lib.helpers.TypefaceHelper;
 import candybar.lib.helpers.WallpaperHelper;
 import candybar.lib.items.Home;
 import candybar.lib.items.Icon;
@@ -665,11 +664,10 @@ public abstract class CandyBarMainActivity extends AppCompatActivity implements
                     (billingResult, s) -> {
                         if (billingResult.getResponseCode() == BillingClient.BillingResponseCode.OK) {
                             Preferences.get(this).setInAppBillingType(-1);
-                            runOnUiThread(() -> new MaterialDialog.Builder(this)
-                                    .typeface(TypefaceHelper.getMedium(this), TypefaceHelper.getRegular(this))
-                                    .title(R.string.navigation_view_donate)
-                                    .content(R.string.donation_success)
-                                    .positiveText(R.string.close)
+                            runOnUiThread(() -> new MaterialAlertDialogBuilder(this)
+                                    .setTitle(R.string.navigation_view_donate)
+                                    .setMessage(R.string.donation_success)
+                                    .setPositiveButton(R.string.close, null)
                                     .show());
                         } else {
                             LogUtil.e("Failed to consume donation product. Response Code: " + billingResult.getResponseCode());

--- a/library/src/main/java/candybar/lib/adapters/HomeAdapter.java
+++ b/library/src/main/java/candybar/lib/adapters/HomeAdapter.java
@@ -31,6 +31,8 @@ import android.widget.TextView;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.appcompat.app.AlertDialog;
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.core.graphics.drawable.RoundedBitmapDrawable;
 import androidx.core.graphics.drawable.RoundedBitmapDrawableFactory;
@@ -39,7 +41,6 @@ import androidx.core.widget.TextViewCompat;
 import androidx.recyclerview.widget.RecyclerView;
 import androidx.recyclerview.widget.StaggeredGridLayoutManager;
 
-import com.afollestad.materialdialogs.MaterialDialog;
 import com.bumptech.glide.Glide;
 import com.bumptech.glide.load.DataSource;
 import com.bumptech.glide.load.engine.DiskCacheStrategy;
@@ -47,9 +48,6 @@ import com.bumptech.glide.load.engine.GlideException;
 import com.bumptech.glide.load.resource.drawable.DrawableTransitionOptions;
 import com.bumptech.glide.request.RequestListener;
 import com.bumptech.glide.request.target.Target;
-import com.danimahardhika.android.helpers.core.ColorHelper;
-import com.danimahardhika.android.helpers.core.DrawableHelper;
-import com.danimahardhika.android.helpers.core.utils.LogUtil;
 import com.google.android.material.card.MaterialCardView;
 
 import org.json.JSONArray;
@@ -79,6 +77,9 @@ import candybar.lib.preferences.Preferences;
 import candybar.lib.utils.AsyncTaskBase;
 import candybar.lib.utils.CandyBarGlideModule;
 import candybar.lib.utils.views.HeaderView;
+import com.danimahardhika.android.helpers.core.ColorHelper;
+import com.danimahardhika.android.helpers.core.DrawableHelper;
+import com.danimahardhika.android.helpers.core.utils.LogUtil;
 
 /*
  * CandyBar - Material Dashboard
@@ -506,22 +507,21 @@ public class HomeAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
 
     private class UpdateChecker extends AsyncTaskBase {
 
-        private MaterialDialog loadingDialog;
+        private AlertDialog loadingDialog;
         private String latestVersion;
         private String updateUrl;
         private String[] changelog;
         private boolean isUpdateAvailable;
 
+        ProgressBar progressBar = new ProgressBar(mContext);
+
         @Override
         protected void preRun() {
-            loadingDialog = new MaterialDialog.Builder(mContext)
-                    .typeface(TypefaceHelper.getMedium(mContext), TypefaceHelper.getRegular(mContext))
-                    .content(R.string.checking_for_update)
-                    .cancelable(false)
-                    .canceledOnTouchOutside(false)
-                    .progress(true, 0)
-                    .progressIndeterminateStyle(true)
-                    .build();
+            loadingDialog = new MaterialAlertDialogBuilder(mContext)
+                    .setMessage(R.string.checking_for_update)
+                    .setCancelable(false)
+                    .setView(progressBar)
+                    .create();
 
             loadingDialog.show();
         }
@@ -590,27 +590,26 @@ public class HomeAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
             loadingDialog = null;
 
             if (ok) {
-                MaterialDialog.Builder builder = new MaterialDialog.Builder(mContext)
-                        .typeface(TypefaceHelper.getMedium(mContext), TypefaceHelper.getRegular(mContext))
-                        .customView(R.layout.fragment_update, false);
+                View view = LayoutInflater.from(mContext).inflate(R.layout.fragment_update, null);
+                AlertDialog.Builder builder = new MaterialAlertDialogBuilder(mContext)
+                        .setView(view);
 
                 if (isUpdateAvailable) {
                     builder
-                            .positiveText(R.string.update)
-                            .negativeText(R.string.close)
-                            .onPositive((dialog, which) -> {
+                            .setPositiveButton(R.string.update, (dialog, which) -> {
                                 Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(updateUrl));
                                 intent.addFlags(Intent.FLAG_ACTIVITY_BROUGHT_TO_FRONT);
                                 mContext.startActivity(intent);
-                            });
+                            })
+                            .setNegativeButton(R.string.close, null);
                 } else {
-                    builder.positiveText(R.string.close);
+                    builder.setPositiveButton(R.string.close, null);
                 }
 
-                MaterialDialog dialog = builder.build();
+                AlertDialog dialog = builder.create();
 
-                TextView changelogVersion = (TextView) dialog.findViewById(R.id.changelog_version);
-                ListView mChangelogList = (ListView) dialog.findViewById(R.id.changelog_list);
+                TextView changelogVersion = view.findViewById(R.id.changelog_version);
+                ListView mChangelogList = view.findViewById(R.id.changelog_list);
 
                 if (isUpdateAvailable) {
                     changelogVersion.setText(
@@ -625,11 +624,9 @@ public class HomeAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
 
                 dialog.show();
             } else {
-                new MaterialDialog.Builder(mContext)
-                        .typeface(TypefaceHelper.getMedium(mContext), TypefaceHelper.getRegular(mContext))
-                        .content(R.string.unable_to_load_config)
-                        .positiveText(R.string.close)
-                        .build()
+                new MaterialAlertDialogBuilder(mContext)
+                        .setMessage(R.string.unable_to_load_config)
+                        .setPositiveButton(R.string.close, null)
                         .show();
             }
         }

--- a/library/src/main/java/candybar/lib/adapters/PresetsAdapter.java
+++ b/library/src/main/java/candybar/lib/adapters/PresetsAdapter.java
@@ -21,7 +21,7 @@ import android.widget.Toast;
 import androidx.annotation.NonNull;
 import androidx.recyclerview.widget.RecyclerView;
 
-import com.afollestad.materialdialogs.MaterialDialog;
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 import com.bumptech.glide.Glide;
 import com.bumptech.glide.load.engine.DiskCacheStrategy;
 import com.bumptech.glide.load.resource.bitmap.BitmapTransitionOptions;
@@ -39,7 +39,6 @@ import java.util.Locale;
 
 import candybar.lib.R;
 import candybar.lib.applications.CandyBarApplication;
-import candybar.lib.helpers.TypefaceHelper;
 import candybar.lib.items.Preset;
 import candybar.lib.preferences.Preferences;
 import candybar.lib.utils.CandyBarGlideModule;
@@ -297,10 +296,9 @@ public class PresetsAdapter extends RecyclerView.Adapter<PresetsAdapter.ViewHold
                     }
 
                     if (!getRequiredApps(type).isEmpty()) {
-                        new MaterialDialog.Builder(mContext)
-                                .typeface(TypefaceHelper.getMedium(mContext), TypefaceHelper.getRegular(mContext))
-                                .content(R.string.presets_required_apps_not_installed)
-                                .positiveText(R.string.close)
+                        new MaterialAlertDialogBuilder(mContext)
+                                .setMessage(R.string.presets_required_apps_not_installed)
+                                .setPositiveButton(R.string.close, null)
                                 .show();
                     } else {
                         mContext.startActivity(intent);

--- a/library/src/main/java/candybar/lib/adapters/RequestAdapter.java
+++ b/library/src/main/java/candybar/lib/adapters/RequestAdapter.java
@@ -20,7 +20,7 @@ import androidx.appcompat.content.res.AppCompatResources;
 import androidx.recyclerview.widget.RecyclerView;
 import androidx.recyclerview.widget.StaggeredGridLayoutManager;
 
-import com.afollestad.materialdialogs.MaterialDialog;
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 import com.bumptech.glide.Glide;
 import com.bumptech.glide.load.engine.DiskCacheStrategy;
 import com.bumptech.glide.load.resource.drawable.DrawableTransitionOptions;
@@ -34,7 +34,6 @@ import java.util.List;
 
 import candybar.lib.R;
 import candybar.lib.applications.CandyBarApplication;
-import candybar.lib.helpers.TypefaceHelper;
 import candybar.lib.items.Request;
 import candybar.lib.preferences.Preferences;
 import candybar.lib.utils.CandyBarGlideModule;
@@ -235,11 +234,10 @@ public class RequestAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder
                 contentViewHolder.infoIcon.setImageDrawable(AppCompatResources.getDrawable(mContext, R.drawable.ic_drawer_about));
                 contentViewHolder.infoIcon.setColorFilter(mTextColorSecondary);
                 int pos = finalPosition;
-                contentViewHolder.infoIcon.setOnClickListener(v -> new MaterialDialog.Builder(mContext)
-                        .typeface(TypefaceHelper.getMedium(mContext), TypefaceHelper.getRegular(mContext))
-                        .title(mRequests.get(pos).getName())
-                        .content(mRequests.get(pos).getInfoText())
-                        .positiveText(android.R.string.yes)
+                contentViewHolder.infoIcon.setOnClickListener(v -> new MaterialAlertDialogBuilder(mContext)
+                        .setTitle(mRequests.get(pos).getName())
+                        .setMessage(mRequests.get(pos).getInfoText())
+                        .setPositiveButton(android.R.string.yes, null)
                         .show());
             }
 
@@ -507,16 +505,12 @@ public class RequestAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder
                 if (isDuplicateRequestAllowed) {
                     // Icon was already requested but re-request is allowed
                     // Ask user if they really want to re-request the icon
-                    new MaterialDialog.Builder(mContext)
-                            .typeface(TypefaceHelper.getMedium(mContext), TypefaceHelper.getRegular(mContext))
-                            .title(R.string.request_already_requested)
-                            .content(R.string.request_requested_possible)
-                            .cancelable(false)
-                            .canceledOnTouchOutside(false)
-                            .negativeText(R.string.request_requested_button_cancel)
-                            .onNegative((dialog, which) -> toggleListener.onNegativeResult())
-                            .positiveText(R.string.request_requested_button_confirm)
-                            .onPositive((dialog, which) -> {
+                    new MaterialAlertDialogBuilder(mContext)
+                            .setTitle(R.string.request_already_requested)
+                            .setMessage(R.string.request_requested_possible)
+                            .setCancelable(false)
+                            .setNegativeButton(R.string.request_requested_button_cancel, (dialog, which) -> toggleListener.onNegativeResult())
+                            .setPositiveButton(R.string.request_requested_button_confirm, (dialog, which) -> {
                                 mSelectedItems.put(position, true);
                                 toggleListener.onPositiveResult();
                             })
@@ -524,22 +518,20 @@ public class RequestAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder
                 } else {
                     // Re-requesting icons is not allowed
                     toggleListener.onNegativeResult();
-                    new MaterialDialog.Builder(mContext)
-                            .typeface(TypefaceHelper.getMedium(mContext), TypefaceHelper.getRegular(mContext))
-                            .title(R.string.request_not_available)
-                            .content(R.string.request_requested)
-                            .negativeText(R.string.request_requested_button_cancel)
+                    new MaterialAlertDialogBuilder(mContext)
+                            .setTitle(R.string.request_not_available)
+                            .setMessage(R.string.request_requested)
+                            .setNegativeButton(R.string.request_requested_button_cancel, null)
                             .show();
                 }
             } else if (!mRequests.get(position).isAvailableForRequest()) {
                 // Icon is not available for request
                 toggleListener.onNegativeResult();
                 if (!mRequests.get(position).getInfoText().isEmpty()) {
-                    new MaterialDialog.Builder(mContext)
-                            .typeface(TypefaceHelper.getMedium(mContext), TypefaceHelper.getRegular(mContext))
-                            .title(mContext.getResources().getString(R.string.request_not_available))
-                            .content(mRequests.get(position).getInfoText())
-                            .positiveText(android.R.string.yes)
+                    new MaterialAlertDialogBuilder(mContext)
+                            .setTitle(mContext.getResources().getString(R.string.request_not_available))
+                            .setMessage(mRequests.get(position).getInfoText())
+                            .setPositiveButton(android.R.string.yes, null)
                             .show();
                 }
             } else {

--- a/library/src/main/java/candybar/lib/adapters/SettingsAdapter.java
+++ b/library/src/main/java/candybar/lib/adapters/SettingsAdapter.java
@@ -23,7 +23,7 @@ import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentManager;
 import androidx.recyclerview.widget.RecyclerView;
 
-import com.afollestad.materialdialogs.MaterialDialog;
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 import com.danimahardhika.android.helpers.core.ColorHelper;
 import com.danimahardhika.android.helpers.core.DrawableHelper;
 import com.danimahardhika.android.helpers.core.FileHelper;
@@ -45,7 +45,6 @@ import candybar.lib.fragments.dialog.ChangelogFragment;
 import candybar.lib.fragments.dialog.LanguagesFragment;
 import candybar.lib.fragments.dialog.ThemeChooserFragment;
 import candybar.lib.helpers.ReportBugsHelper;
-import candybar.lib.helpers.TypefaceHelper;
 import candybar.lib.items.Setting;
 import candybar.lib.preferences.Preferences;
 import candybar.lib.tasks.IconRequestTask;
@@ -241,12 +240,9 @@ public class SettingsAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolde
                                     put("item", "clear_cache");
                                 }}
                         );
-                        new MaterialDialog.Builder(mContext)
-                                .typeface(TypefaceHelper.getMedium(mContext), TypefaceHelper.getRegular(mContext))
-                                .content(R.string.pref_data_cache_clear_dialog)
-                                .positiveText(R.string.clear)
-                                .negativeText(android.R.string.cancel)
-                                .onPositive((dialog, which) -> {
+                        new MaterialAlertDialogBuilder(mContext)
+                                .setMessage(R.string.pref_data_cache_clear_dialog)
+                                .setPositiveButton(R.string.clear, (dialog, which) -> {
                                     CandyBarApplication.getConfiguration().getAnalyticsHandler().logEvent(
                                             "click",
                                             new HashMap<>() {{
@@ -272,7 +268,7 @@ public class SettingsAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolde
                                         LogUtil.e(Log.getStackTraceString(e));
                                     }
                                 })
-                                .onNegative(((dialog, which) -> {
+                                .setNegativeButton(android.R.string.cancel, ((dialog, which) -> {
                                     CandyBarApplication.getConfiguration().getAnalyticsHandler().logEvent(
                                             "click",
                                             new HashMap<>() {{
@@ -293,12 +289,9 @@ public class SettingsAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolde
                                     put("item", "clear_icon_request_data");
                                 }}
                         );
-                        new MaterialDialog.Builder(mContext)
-                                .typeface(TypefaceHelper.getMedium(mContext), TypefaceHelper.getRegular(mContext))
-                                .content(R.string.pref_data_request_clear_dialog)
-                                .positiveText(R.string.clear)
-                                .negativeText(android.R.string.cancel)
-                                .onPositive((dialog, which) -> {
+                        new MaterialAlertDialogBuilder(mContext)
+                                .setMessage(R.string.pref_data_request_clear_dialog)
+                                .setPositiveButton(R.string.clear, (dialog, which) -> {
                                     CandyBarApplication.getConfiguration().getAnalyticsHandler().logEvent(
                                             "click",
                                             new HashMap<>() {{
@@ -315,7 +308,7 @@ public class SettingsAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolde
                                     Toast.makeText(mContext, R.string.pref_data_request_cleared,
                                             Toast.LENGTH_LONG).show();
                                 })
-                                .onNegative(((dialog, which) -> {
+                                .setNegativeButton(android.R.string.cancel, ((dialog, which) -> {
                                     CandyBarApplication.getConfiguration().getAnalyticsHandler().logEvent(
                                             "click",
                                             new HashMap<>() {{

--- a/library/src/main/java/candybar/lib/adapters/dialog/IntentAdapter.java
+++ b/library/src/main/java/candybar/lib/adapters/dialog/IntentAdapter.java
@@ -31,7 +31,7 @@ import candybar.lib.items.Request;
 import candybar.lib.tasks.IconRequestBuilderTask;
 import candybar.lib.tasks.PremiumRequestBuilderTask;
 import candybar.lib.utils.AsyncTaskBase;
-import me.zhanghai.android.materialprogressbar.MaterialProgressBar;
+import android.widget.ProgressBar;
 
 /*
  * CandyBar - Material Dashboard
@@ -166,7 +166,7 @@ public class IntentAdapter extends BaseAdapter {
         private final TextView type;
         private final ImageView icon;
         private final LinearLayout container;
-        private final MaterialProgressBar progressBar;
+        private final ProgressBar progressBar;
 
         ViewHolder(View view) {
             name = view.findViewById(R.id.name);

--- a/library/src/main/java/candybar/lib/fragments/RequestFragment.java
+++ b/library/src/main/java/candybar/lib/fragments/RequestFragment.java
@@ -35,7 +35,8 @@ import androidx.recyclerview.widget.DefaultItemAnimator;
 import androidx.recyclerview.widget.RecyclerView;
 import androidx.recyclerview.widget.StaggeredGridLayoutManager;
 
-import com.afollestad.materialdialogs.MaterialDialog;
+import androidx.appcompat.app.AlertDialog;
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 import com.android.billingclient.api.BillingClient;
 import com.android.billingclient.api.Purchase;
 import com.danimahardhika.android.helpers.animation.AnimationHelper;
@@ -69,7 +70,6 @@ import candybar.lib.fragments.dialog.IntentChooserFragment;
 import candybar.lib.helpers.IconsHelper;
 import candybar.lib.helpers.RequestHelper;
 import candybar.lib.helpers.TapIntroHelper;
-import candybar.lib.helpers.TypefaceHelper;
 import candybar.lib.items.Request;
 import candybar.lib.preferences.Preferences;
 import candybar.lib.utils.AsyncTaskBase;
@@ -395,7 +395,7 @@ public class RequestFragment extends Fragment implements View.OnClickListener {
 
     private class RequestLoader extends AsyncTaskBase {
 
-        private MaterialDialog dialog;
+        private AlertDialog dialog;
         private boolean isPacific;
         private String pacificApiKey;
         private boolean isCustom;
@@ -416,14 +416,12 @@ public class RequestFragment extends Fragment implements View.OnClickListener {
                 pacificApiKey = RequestHelper.getRegularPacificApiKey(requireActivity());
             }
 
-            dialog = new MaterialDialog.Builder(requireActivity())
-                    .typeface(TypefaceHelper.getMedium(requireActivity()), TypefaceHelper.getRegular(requireActivity()))
-                    .content(R.string.request_building)
-                    .cancelable(false)
-                    .canceledOnTouchOutside(false)
-                    .progress(true, 0)
-                    .progressIndeterminateStyle(true)
-                    .build();
+            ProgressBar progressBar = new ProgressBar(requireActivity());
+            dialog = new MaterialAlertDialogBuilder(requireActivity())
+                    .setMessage(R.string.request_building)
+                    .setCancelable(false)
+                    .setView(progressBar)
+                    .create();
 
             dialog.show();
         }
@@ -561,13 +559,10 @@ public class RequestFragment extends Fragment implements View.OnClickListener {
             } else {
                 if (isPacific || isCustom) {
                     int content = isPacific ? R.string.request_pacific_error : R.string.request_custom_error;
-                    new MaterialDialog.Builder(getActivity())
-                            .typeface(TypefaceHelper.getMedium(getActivity()), TypefaceHelper.getRegular(getActivity()))
-                            .content(content, "\"" + errorMessage + "\"")
-                            .cancelable(true)
-                            .canceledOnTouchOutside(false)
-                            .positiveText(R.string.close)
-                            .build()
+                    new MaterialAlertDialogBuilder(getActivity())
+                            .setMessage(getActivity().getResources().getString(content, "\"" + errorMessage + "\""))
+                            .setCancelable(true)
+                            .setPositiveButton(R.string.close, null)
                             .show();
                 } else if (noEmailClientError) {
                     Toast.makeText(getActivity(), R.string.no_email_app,
@@ -582,20 +577,18 @@ public class RequestFragment extends Fragment implements View.OnClickListener {
 
     public class CheckConfig extends AsyncTaskBase {
 
-        private MaterialDialog dialog;
+        private AlertDialog dialog;
         private boolean canRequest = true;
         private String updateUrl;
 
         @Override
         protected void preRun() {
-            dialog = new MaterialDialog.Builder(requireActivity())
-                    .typeface(TypefaceHelper.getMedium(requireActivity()), TypefaceHelper.getRegular(requireActivity()))
-                    .content(R.string.request_fetching_data)
-                    .cancelable(false)
-                    .canceledOnTouchOutside(false)
-                    .progress(true, 0)
-                    .progressIndeterminateStyle(true)
-                    .build();
+            ProgressBar progressBar = new ProgressBar(requireActivity());
+            dialog = new MaterialAlertDialogBuilder(requireActivity())
+                    .setMessage(R.string.request_fetching_data)
+                    .setCancelable(false)
+                    .setView(progressBar)
+                    .create();
 
             dialog.show();
         }
@@ -661,19 +654,15 @@ public class RequestFragment extends Fragment implements View.OnClickListener {
 
             if (ok) {
                 if (!canRequest) {
-                    new MaterialDialog.Builder(requireActivity())
-                            .typeface(TypefaceHelper.getMedium(requireActivity()), TypefaceHelper.getRegular(requireActivity()))
-                            .content(R.string.request_app_disabled)
-                            .negativeText(R.string.close)
-                            .positiveText(R.string.update)
-                            .onPositive(((dialog, which) -> {
+                    new MaterialAlertDialogBuilder(requireActivity())
+                            .setMessage(R.string.request_app_disabled)
+                            .setNegativeButton(R.string.close, null)
+                            .setPositiveButton(R.string.update, ((dialog, which) -> {
                                 Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(updateUrl));
                                 intent.addFlags(Intent.FLAG_ACTIVITY_BROUGHT_TO_FRONT);
                                 requireActivity().startActivity(intent);
                             }))
-                            .cancelable(false)
-                            .canceledOnTouchOutside(false)
-                            .build()
+                            .setCancelable(false)
                             .show();
 
                     mAdapter.resetSelectedItems();
@@ -682,12 +671,9 @@ public class RequestFragment extends Fragment implements View.OnClickListener {
                     mAsyncTask = new RequestLoader().executeOnThreadPool();
                 }
             } else {
-                new MaterialDialog.Builder(requireActivity())
-                        .typeface(TypefaceHelper.getMedium(requireActivity()), TypefaceHelper.getRegular(requireActivity()))
-                        .content(R.string.unable_to_load_config)
-                        .canceledOnTouchOutside(false)
-                        .positiveText(R.string.close)
-                        .build()
+                new MaterialAlertDialogBuilder(requireActivity())
+                        .setMessage(R.string.unable_to_load_config)
+                        .setPositiveButton(R.string.close, null)
                         .show();
             }
         }

--- a/library/src/main/java/candybar/lib/fragments/SettingsFragment.java
+++ b/library/src/main/java/candybar/lib/fragments/SettingsFragment.java
@@ -20,7 +20,9 @@ import androidx.recyclerview.widget.DefaultItemAnimator;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
-import com.afollestad.materialdialogs.MaterialDialog;
+import androidx.appcompat.app.AlertDialog;
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
+import android.widget.ProgressBar;
 import com.danimahardhika.android.helpers.core.FileHelper;
 import com.danimahardhika.android.helpers.core.utils.LogUtil;
 
@@ -39,7 +41,6 @@ import candybar.lib.fragments.dialog.IntentChooserFragment;
 import candybar.lib.helpers.IconsHelper;
 import candybar.lib.helpers.LocaleHelper;
 import candybar.lib.helpers.RequestHelper;
-import candybar.lib.helpers.TypefaceHelper;
 import candybar.lib.items.Language;
 import candybar.lib.items.Request;
 import candybar.lib.items.Setting;
@@ -231,7 +232,7 @@ public class SettingsFragment extends Fragment {
 
     private class PremiumRequestRebuilder extends AsyncTaskBase {
 
-        private MaterialDialog dialog;
+        private AlertDialog dialog;
         private boolean isPacific;
         private String pacificApiKey;
         private boolean isCustom;
@@ -246,14 +247,12 @@ public class SettingsFragment extends Fragment {
             isCustom = RequestHelper.isPremiumCustomEnabled(requireActivity());
             isPremium = true;
 
-            dialog = new MaterialDialog.Builder(requireActivity())
-                    .typeface(TypefaceHelper.getMedium(requireActivity()), TypefaceHelper.getRegular(requireActivity()))
-                    .content(R.string.premium_request_rebuilding)
-                    .cancelable(false)
-                    .canceledOnTouchOutside(false)
-                    .progress(true, 0)
-                    .progressIndeterminateStyle(true)
-                    .build();
+            ProgressBar progressBar = new ProgressBar(requireActivity());
+            dialog = new MaterialAlertDialogBuilder(requireActivity())
+                    .setMessage(R.string.premium_request_rebuilding)
+                    .setCancelable(false)
+                    .setView(progressBar)
+                    .create();
 
             dialog.show();
         }

--- a/library/src/main/java/candybar/lib/fragments/dialog/ChangelogFragment.java
+++ b/library/src/main/java/candybar/lib/fragments/dialog/ChangelogFragment.java
@@ -14,11 +14,12 @@ import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentManager;
 import androidx.fragment.app.FragmentTransaction;
 
-import com.afollestad.materialdialogs.MaterialDialog;
+import androidx.appcompat.app.AlertDialog;
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
+import android.view.LayoutInflater;
 
 import candybar.lib.R;
 import candybar.lib.adapters.dialog.ChangelogAdapter;
-import candybar.lib.helpers.TypefaceHelper;
 import candybar.lib.utils.listeners.HomeListener;
 
 /*
@@ -70,17 +71,15 @@ public class ChangelogFragment extends DialogFragment {
     @NonNull
     @Override
     public Dialog onCreateDialog(Bundle savedInstanceState) {
-        MaterialDialog dialog = new MaterialDialog.Builder(requireActivity())
-                .typeface(TypefaceHelper.getMedium(requireActivity()), TypefaceHelper.getRegular(requireActivity()))
-                .customView(R.layout.fragment_changelog, false)
-                .positiveText(R.string.close)
-                .onPositive((d, which) -> this.onPositive.run())
-                .build();
-        dialog.show();
+        View view = LayoutInflater.from(requireActivity()).inflate(R.layout.fragment_changelog, null);
+        AlertDialog dialog = new MaterialAlertDialogBuilder(requireActivity())
+                .setView(view)
+                .setPositiveButton(R.string.close, (d, which) -> this.onPositive.run())
+                .create();
 
-        ListView changelogList = (ListView) dialog.findViewById(R.id.changelog_list);
-        TextView changelogDate = (TextView) dialog.findViewById(R.id.changelog_date);
-        TextView changelogVersion = (TextView) dialog.findViewById(R.id.changelog_version);
+        ListView changelogList = view.findViewById(R.id.changelog_list);
+        TextView changelogDate = view.findViewById(R.id.changelog_date);
+        TextView changelogVersion = view.findViewById(R.id.changelog_version);
 
         Activity activity = requireActivity();
         try {

--- a/library/src/main/java/candybar/lib/fragments/dialog/CreditsFragment.java
+++ b/library/src/main/java/candybar/lib/fragments/dialog/CreditsFragment.java
@@ -12,7 +12,10 @@ import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentManager;
 import androidx.fragment.app.FragmentTransaction;
 
-import com.afollestad.materialdialogs.MaterialDialog;
+import androidx.appcompat.app.AlertDialog;
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
+import android.view.LayoutInflater;
+import android.view.View;
 import com.danimahardhika.android.helpers.core.utils.LogUtil;
 
 import org.xmlpull.v1.XmlPullParser;
@@ -22,7 +25,6 @@ import java.util.List;
 
 import candybar.lib.R;
 import candybar.lib.adapters.dialog.CreditsAdapter;
-import candybar.lib.helpers.TypefaceHelper;
 import candybar.lib.items.Credit;
 import candybar.lib.utils.AsyncTaskBase;
 
@@ -82,14 +84,13 @@ public class CreditsFragment extends DialogFragment {
     @NonNull
     @Override
     public Dialog onCreateDialog(Bundle savedInstanceState) {
-        MaterialDialog dialog = new MaterialDialog.Builder(requireActivity())
-                .customView(R.layout.fragment_credits, false)
-                .typeface(TypefaceHelper.getMedium(requireActivity()), TypefaceHelper.getRegular(requireActivity()))
-                .title(getTitle(mType))
-                .positiveText(R.string.close)
-                .build();
-        dialog.show();
-        mListView = (ListView) dialog.findViewById(R.id.listview);
+        View view = LayoutInflater.from(requireActivity()).inflate(R.layout.fragment_credits, null);
+        AlertDialog dialog = new MaterialAlertDialogBuilder(requireActivity())
+                .setTitle(getTitle(mType))
+                .setView(view)
+                .setPositiveButton(R.string.close, null)
+                .create();
+        mListView = view.findViewById(R.id.listview);
         mAsyncTask = new CreditsLoader().executeOnThreadPool();
 
         return dialog;

--- a/library/src/main/java/candybar/lib/fragments/dialog/DonationLinksFragment.java
+++ b/library/src/main/java/candybar/lib/fragments/dialog/DonationLinksFragment.java
@@ -10,14 +10,16 @@ import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentManager;
 import androidx.fragment.app.FragmentTransaction;
 
-import com.afollestad.materialdialogs.MaterialDialog;
+import androidx.appcompat.app.AlertDialog;
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
+import android.view.LayoutInflater;
+import android.view.View;
 
 import java.util.List;
 
 import candybar.lib.R;
 import candybar.lib.adapters.dialog.OtherAppsAdapter;
 import candybar.lib.applications.CandyBarApplication;
-import candybar.lib.helpers.TypefaceHelper;
 
 /*
  * CandyBar - Material Dashboard
@@ -62,15 +64,14 @@ public class DonationLinksFragment extends DialogFragment {
     @NonNull
     @Override
     public Dialog onCreateDialog(Bundle savedInstanceState) {
-        MaterialDialog dialog = new MaterialDialog.Builder(requireActivity())
-                .customView(R.layout.fragment_other_apps, false)
-                .typeface(TypefaceHelper.getMedium(requireActivity()), TypefaceHelper.getRegular(requireActivity()))
-                .title(R.string.donate)
-                .positiveText(R.string.close)
-                .build();
-        dialog.show();
+        View view = LayoutInflater.from(requireActivity()).inflate(R.layout.fragment_other_apps, null);
+        AlertDialog dialog = new MaterialAlertDialogBuilder(requireActivity())
+                .setTitle(R.string.donate)
+                .setView(view)
+                .setPositiveButton(R.string.close, null)
+                .create();
 
-        ListView listView = (ListView) dialog.findViewById(R.id.listview);
+        ListView listView = view.findViewById(R.id.listview);
         List<CandyBarApplication.DonationLink> donationLinks = CandyBarApplication.getConfiguration().getDonationLinks();
         if (donationLinks != null) {
             listView.setAdapter(new OtherAppsAdapter(requireActivity(), donationLinks));

--- a/library/src/main/java/candybar/lib/fragments/dialog/IconPreviewFragment.java
+++ b/library/src/main/java/candybar/lib/fragments/dialog/IconPreviewFragment.java
@@ -16,7 +16,9 @@ import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentManager;
 import androidx.fragment.app.FragmentTransaction;
 
-import com.afollestad.materialdialogs.MaterialDialog;
+import androidx.appcompat.app.AlertDialog;
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
+import android.view.LayoutInflater;
 import com.bumptech.glide.Glide;
 import com.bumptech.glide.load.engine.DiskCacheStrategy;
 import com.bumptech.glide.load.resource.drawable.DrawableTransitionOptions;
@@ -30,7 +32,6 @@ import candybar.lib.R;
 import candybar.lib.applications.CandyBarApplication;
 import candybar.lib.databases.Database;
 import candybar.lib.fragments.IconsFragment;
-import candybar.lib.helpers.TypefaceHelper;
 
 /*
  * CandyBar - Material Dashboard
@@ -99,13 +100,11 @@ public class IconPreviewFragment extends DialogFragment {
     @NonNull
     @Override
     public Dialog onCreateDialog(Bundle savedInstanceState) {
-        MaterialDialog dialog = new MaterialDialog.Builder(requireActivity())
-                .customView(R.layout.fragment_icon_preview, false)
-                .typeface(TypefaceHelper.getMedium(requireActivity()), TypefaceHelper.getRegular(requireActivity()))
-                .positiveText(R.string.close)
-                .build();
-
-        dialog.show();
+        View rootView = LayoutInflater.from(requireActivity()).inflate(R.layout.fragment_icon_preview, null);
+        AlertDialog dialog = new MaterialAlertDialogBuilder(requireActivity())
+                .setView(rootView)
+                .setPositiveButton(R.string.close, null)
+                .create();
 
         if (savedInstanceState != null) {
             mIconTitle = savedInstanceState.getString(TITLE);
@@ -113,9 +112,9 @@ public class IconPreviewFragment extends DialogFragment {
             mIconId = savedInstanceState.getInt(ID);
         }
 
-        TextView name = (TextView) dialog.findViewById(R.id.name);
-        ImageView icon = (ImageView) dialog.findViewById(R.id.icon);
-        ImageView bookmark = (ImageView) dialog.findViewById(R.id.bookmark_button);
+        TextView name = rootView.findViewById(R.id.name);
+        ImageView icon = rootView.findViewById(R.id.icon);
+        ImageView bookmark = rootView.findViewById(R.id.bookmark_button);
 
         name.setText(mIconTitle);
 

--- a/library/src/main/java/candybar/lib/fragments/dialog/IconShapeChooserFragment.java
+++ b/library/src/main/java/candybar/lib/fragments/dialog/IconShapeChooserFragment.java
@@ -11,7 +11,10 @@ import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentManager;
 import androidx.fragment.app.FragmentTransaction;
 
-import com.afollestad.materialdialogs.MaterialDialog;
+import androidx.appcompat.app.AlertDialog;
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
+import android.view.LayoutInflater;
+import android.view.View;
 
 import java.util.List;
 
@@ -20,7 +23,6 @@ import candybar.lib.adapters.dialog.IconShapeAdapter;
 import candybar.lib.fragments.IconsFragment;
 import candybar.lib.fragments.IconsSearchFragment;
 import candybar.lib.helpers.IconShapeHelper;
-import candybar.lib.helpers.TypefaceHelper;
 import candybar.lib.items.IconShape;
 import candybar.lib.preferences.Preferences;
 
@@ -69,15 +71,14 @@ public class IconShapeChooserFragment extends DialogFragment {
     @NonNull
     @Override
     public Dialog onCreateDialog(Bundle savedInstanceState) {
-        MaterialDialog dialog = new MaterialDialog.Builder(requireActivity())
-                .customView(R.layout.fragment_languages, false)
-                .typeface(TypefaceHelper.getMedium(requireActivity()), TypefaceHelper.getRegular(requireActivity()))
-                .title(R.string.icon_shape)
-                .negativeText(R.string.close)
-                .build();
-        dialog.show();
+        View view = LayoutInflater.from(requireActivity()).inflate(R.layout.fragment_languages, null);
+        AlertDialog dialog = new MaterialAlertDialogBuilder(requireActivity())
+                .setTitle(R.string.icon_shape)
+                .setView(view)
+                .setNegativeButton(R.string.close, null)
+                .create();
 
-        ListView listView = (ListView) dialog.findViewById(R.id.listview);
+        ListView listView = view.findViewById(R.id.listview);
         List<IconShape> iconShapes = IconShapeHelper.getShapes();
         int currentShape = mShape = Preferences.get(requireActivity()).getIconShape();
         int currentShapeIndex = 0;

--- a/library/src/main/java/candybar/lib/fragments/dialog/InAppBillingFragment.java
+++ b/library/src/main/java/candybar/lib/fragments/dialog/InAppBillingFragment.java
@@ -16,7 +16,9 @@ import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentManager;
 import androidx.fragment.app.FragmentTransaction;
 
-import com.afollestad.materialdialogs.MaterialDialog;
+import androidx.appcompat.app.AlertDialog;
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
+import android.view.LayoutInflater;
 import com.android.billingclient.api.BillingClient;
 import com.android.billingclient.api.ProductDetails;
 import com.android.billingclient.api.QueryProductDetailsParams;
@@ -31,7 +33,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import candybar.lib.R;
 import candybar.lib.adapters.dialog.InAppBillingAdapter;
-import candybar.lib.helpers.TypefaceHelper;
 import candybar.lib.items.InAppBilling;
 import candybar.lib.preferences.Preferences;
 import candybar.lib.utils.AsyncTaskBase;
@@ -118,14 +119,12 @@ public class InAppBillingFragment extends DialogFragment {
     @NonNull
     @Override
     public Dialog onCreateDialog(Bundle savedInstanceState) {
-        MaterialDialog.Builder builder = new MaterialDialog.Builder(requireActivity());
-        builder.title(mType == InAppBilling.DONATE ?
-                R.string.navigation_view_donate : R.string.premium_request)
-                .customView(R.layout.fragment_inapp_dialog, false)
-                .typeface(TypefaceHelper.getMedium(requireActivity()), TypefaceHelper.getRegular(requireActivity()))
-                .positiveText(mType == InAppBilling.DONATE ? R.string.donate : R.string.premium_request_buy)
-                .negativeText(R.string.close)
-                .onPositive((dialog, which) -> {
+        View view = LayoutInflater.from(requireActivity()).inflate(R.layout.fragment_inapp_dialog, null);
+        AlertDialog dialog = new MaterialAlertDialogBuilder(requireActivity())
+                .setTitle(mType == InAppBilling.DONATE ?
+                        R.string.navigation_view_donate : R.string.premium_request)
+                .setView(view)
+                .setPositiveButton(mType == InAppBilling.DONATE ? R.string.donate : R.string.premium_request_buy, (d, which) -> {
                     if (mAsyncTask == null) {
                         try {
                             InAppBillingListener listener = (InAppBillingListener) requireActivity();
@@ -136,16 +135,15 @@ public class InAppBillingFragment extends DialogFragment {
                         dismiss();
                     }
                 })
-                .onNegative((dialog, which) ->
-                        Preferences.get(requireActivity()).setInAppBillingType(-1));
-        MaterialDialog dialog = builder.build();
+                .setNegativeButton(R.string.close, (d, which) ->
+                        Preferences.get(requireActivity()).setInAppBillingType(-1))
+                .create();
         dialog.setCancelable(false);
         dialog.setCanceledOnTouchOutside(false);
-        dialog.show();
         setCancelable(false);
 
-        mInAppList = (ListView) dialog.findViewById(R.id.inapp_list);
-        mProgress = (ProgressBar) dialog.findViewById(R.id.progress);
+        mInAppList = view.findViewById(R.id.inapp_list);
+        mProgress = view.findViewById(R.id.progress);
 
         if (savedInstanceState != null) {
             mType = savedInstanceState.getInt(TYPE);

--- a/library/src/main/java/candybar/lib/fragments/dialog/IntentChooserFragment.java
+++ b/library/src/main/java/candybar/lib/fragments/dialog/IntentChooserFragment.java
@@ -22,8 +22,9 @@ import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentManager;
 import androidx.fragment.app.FragmentTransaction;
 
-import com.afollestad.materialdialogs.DialogAction;
-import com.afollestad.materialdialogs.MaterialDialog;
+import androidx.appcompat.app.AlertDialog;
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
+import android.view.LayoutInflater;
 import com.danimahardhika.android.helpers.core.utils.LogUtil;
 
 import java.io.File;
@@ -35,7 +36,6 @@ import candybar.lib.R;
 import candybar.lib.adapters.dialog.IntentAdapter;
 import candybar.lib.applications.CandyBarApplication;
 import candybar.lib.fragments.RequestFragment;
-import candybar.lib.helpers.TypefaceHelper;
 import candybar.lib.items.IntentChooser;
 import candybar.lib.utils.AsyncTaskBase;
 
@@ -105,36 +105,37 @@ public class IntentChooserFragment extends DialogFragment {
     @NonNull
     @Override
     public Dialog onCreateDialog(Bundle savedInstanceState) {
-        MaterialDialog dialog = new MaterialDialog.Builder(requireActivity())
-                .customView(R.layout.fragment_intent_chooser, false)
-                .typeface(TypefaceHelper.getMedium(requireActivity()), TypefaceHelper.getRegular(requireActivity()))
-                .positiveText(android.R.string.cancel)
-                .build();
+        View view = LayoutInflater.from(requireActivity()).inflate(R.layout.fragment_intent_chooser, null);
+        AlertDialog dialog = new MaterialAlertDialogBuilder(requireActivity())
+                .setView(view)
+                .setPositiveButton(android.R.string.cancel, null)
+                .create();
 
-        dialog.getActionButton(DialogAction.POSITIVE).setOnClickListener(view -> {
-            if (mAdapter == null || mAdapter.isAsyncTaskRunning()) return;
+        dialog.setOnShowListener(d -> {
+            dialog.getButton(AlertDialog.BUTTON_POSITIVE).setOnClickListener(v -> {
+                if (mAdapter == null || mAdapter.isAsyncTaskRunning()) return;
 
-            if (CandyBarApplication.sZipPath != null) {
-                File file = new File(CandyBarApplication.sZipPath);
-                if (file.exists()) {
-                    if (file.delete()) {
-                        LogUtil.e(String.format("Intent chooser cancel: %s deleted", file.getName()));
+                if (CandyBarApplication.sZipPath != null) {
+                    File file = new File(CandyBarApplication.sZipPath);
+                    if (file.exists()) {
+                        if (file.delete()) {
+                            LogUtil.e(String.format("Intent chooser cancel: %s deleted", file.getName()));
+                        }
                     }
                 }
-            }
 
-            RequestFragment.sSelectedRequests = null;
-            CandyBarApplication.sRequestProperty = null;
-            CandyBarApplication.sZipPath = null;
-            dialog.dismiss();
+                RequestFragment.sSelectedRequests = null;
+                CandyBarApplication.sRequestProperty = null;
+                CandyBarApplication.sZipPath = null;
+                dialog.dismiss();
+            });
         });
         dialog.setCancelable(false);
         dialog.setCanceledOnTouchOutside(false);
-        dialog.show();
         setCancelable(false);
 
-        mIntentList = (ListView) dialog.findViewById(R.id.intent_list);
-        mNoApp = (TextView) dialog.findViewById(R.id.intent_noapp);
+        mIntentList = view.findViewById(R.id.intent_list);
+        mNoApp = view.findViewById(R.id.intent_noapp);
         mAsyncTask = new IntentChooserLoader().execute();
 
         return dialog;

--- a/library/src/main/java/candybar/lib/fragments/dialog/LanguagesFragment.java
+++ b/library/src/main/java/candybar/lib/fragments/dialog/LanguagesFragment.java
@@ -12,7 +12,10 @@ import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentManager;
 import androidx.fragment.app.FragmentTransaction;
 
-import com.afollestad.materialdialogs.MaterialDialog;
+import androidx.appcompat.app.AlertDialog;
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
+import android.view.LayoutInflater;
+import android.view.View;
 import com.danimahardhika.android.helpers.core.utils.LogUtil;
 
 import java.util.HashMap;
@@ -23,7 +26,6 @@ import candybar.lib.R;
 import candybar.lib.adapters.dialog.LanguagesAdapter;
 import candybar.lib.applications.CandyBarApplication;
 import candybar.lib.helpers.LocaleHelper;
-import candybar.lib.helpers.TypefaceHelper;
 import candybar.lib.items.Language;
 import candybar.lib.preferences.Preferences;
 import candybar.lib.utils.AsyncTaskBase;
@@ -75,12 +77,11 @@ public class LanguagesFragment extends DialogFragment {
     @NonNull
     @Override
     public Dialog onCreateDialog(Bundle savedInstanceState) {
-        MaterialDialog dialog = new MaterialDialog.Builder(requireActivity())
-                .customView(R.layout.fragment_languages, false)
-                .typeface(TypefaceHelper.getMedium(requireActivity()), TypefaceHelper.getRegular(requireActivity()))
-                .title(R.string.pref_language_header)
-                .negativeText(R.string.close)
-                .onNegative(((_dialog, which) -> {
+        View view = LayoutInflater.from(requireActivity()).inflate(R.layout.fragment_languages, null);
+        AlertDialog dialog = new MaterialAlertDialogBuilder(requireActivity())
+                .setTitle(R.string.pref_language_header)
+                .setView(view)
+                .setNegativeButton(R.string.close, (d, which) -> {
                     CandyBarApplication.getConfiguration().getAnalyticsHandler().logEvent(
                             "click",
                             new HashMap<>() {{
@@ -89,11 +90,10 @@ public class LanguagesFragment extends DialogFragment {
                                 put("item", "change_language");
                             }}
                     );
-                }))
-                .build();
-        dialog.show();
+                })
+                .create();
 
-        mListView = (ListView) dialog.findViewById(R.id.listview);
+        mListView = view.findViewById(R.id.listview);
         mAsyncTask = new LanguagesLoader().executeOnThreadPool();
 
         return dialog;

--- a/library/src/main/java/candybar/lib/fragments/dialog/LicensesFragment.java
+++ b/library/src/main/java/candybar/lib/fragments/dialog/LicensesFragment.java
@@ -12,7 +12,10 @@ import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentManager;
 import androidx.fragment.app.FragmentTransaction;
 
-import com.afollestad.materialdialogs.MaterialDialog;
+import androidx.appcompat.app.AlertDialog;
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
+import android.view.LayoutInflater;
+import android.view.View;
 import com.danimahardhika.android.helpers.core.utils.LogUtil;
 
 import org.xmlpull.v1.XmlPullParser;
@@ -22,7 +25,6 @@ import java.util.List;
 
 import candybar.lib.R;
 import candybar.lib.adapters.dialog.LicensesAdapter;
-import candybar.lib.helpers.TypefaceHelper;
 import candybar.lib.items.License;
 import candybar.lib.utils.AsyncTaskBase;
 
@@ -72,15 +74,14 @@ public class LicensesFragment extends DialogFragment {
     @NonNull
     @Override
     public Dialog onCreateDialog(Bundle savedInstanceState) {
-        MaterialDialog dialog = new MaterialDialog.Builder(requireActivity())
-                .customView(R.layout.fragment_licenses, false)
-                .typeface(TypefaceHelper.getMedium(requireActivity()), TypefaceHelper.getRegular(requireActivity()))
-                .title(R.string.about_open_source_licenses)
-                .negativeText(R.string.close)
-                .build();
-        dialog.show();
+        View view = LayoutInflater.from(requireActivity()).inflate(R.layout.fragment_licenses, null);
+        AlertDialog dialog = new MaterialAlertDialogBuilder(requireActivity())
+                .setTitle(R.string.about_open_source_licenses)
+                .setView(view)
+                .setNegativeButton(R.string.close, null)
+                .create();
 
-        mListView = (ListView) dialog.findViewById(R.id.licenses_list);
+        mListView = view.findViewById(R.id.licenses_list);
 
         mAsyncTask = new LicensesLoader().executeOnThreadPool();
 

--- a/library/src/main/java/candybar/lib/fragments/dialog/OtherAppsFragment.java
+++ b/library/src/main/java/candybar/lib/fragments/dialog/OtherAppsFragment.java
@@ -10,14 +10,16 @@ import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentManager;
 import androidx.fragment.app.FragmentTransaction;
 
-import com.afollestad.materialdialogs.MaterialDialog;
+import androidx.appcompat.app.AlertDialog;
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
+import android.view.LayoutInflater;
+import android.view.View;
 
 import java.util.List;
 
 import candybar.lib.R;
 import candybar.lib.adapters.dialog.OtherAppsAdapter;
 import candybar.lib.applications.CandyBarApplication;
-import candybar.lib.helpers.TypefaceHelper;
 
 /*
  * CandyBar - Material Dashboard
@@ -62,15 +64,14 @@ public class OtherAppsFragment extends DialogFragment {
     @NonNull
     @Override
     public Dialog onCreateDialog(Bundle savedInstanceState) {
-        MaterialDialog dialog = new MaterialDialog.Builder(requireActivity())
-                .customView(R.layout.fragment_other_apps, false)
-                .typeface(TypefaceHelper.getMedium(requireActivity()), TypefaceHelper.getRegular(requireActivity()))
-                .title(R.string.home_more_apps_header)
-                .positiveText(R.string.close)
-                .build();
-        dialog.show();
+        View view = LayoutInflater.from(requireActivity()).inflate(R.layout.fragment_other_apps, null);
+        AlertDialog dialog = new MaterialAlertDialogBuilder(requireActivity())
+                .setTitle(R.string.home_more_apps_header)
+                .setView(view)
+                .setPositiveButton(R.string.close, null)
+                .create();
 
-        ListView listView = (ListView) dialog.findViewById(R.id.listview);
+        ListView listView = view.findViewById(R.id.listview);
         List<CandyBarApplication.OtherApp> otherApps = CandyBarApplication.getConfiguration().getOtherApps();
         if (otherApps != null) {
             listView.setAdapter(new OtherAppsAdapter(requireActivity(), otherApps));

--- a/library/src/main/java/candybar/lib/fragments/dialog/ThemeChooserFragment.java
+++ b/library/src/main/java/candybar/lib/fragments/dialog/ThemeChooserFragment.java
@@ -11,13 +11,15 @@ import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentManager;
 import androidx.fragment.app.FragmentTransaction;
 
-import com.afollestad.materialdialogs.MaterialDialog;
+import androidx.appcompat.app.AlertDialog;
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
+import android.view.LayoutInflater;
+import android.view.View;
 
 import java.util.Arrays;
 
 import candybar.lib.R;
 import candybar.lib.adapters.dialog.ThemeAdapter;
-import candybar.lib.helpers.TypefaceHelper;
 import candybar.lib.items.Theme;
 import candybar.lib.preferences.Preferences;
 
@@ -67,15 +69,14 @@ public class ThemeChooserFragment extends DialogFragment {
     @NonNull
     @Override
     public Dialog onCreateDialog(Bundle savedInstanceState) {
-        MaterialDialog dialog = new MaterialDialog.Builder(requireActivity())
-                .customView(R.layout.fragment_languages, false)
-                .typeface(TypefaceHelper.getMedium(requireActivity()), TypefaceHelper.getRegular(requireActivity()))
-                .title(R.string.pref_theme_header)
-                .negativeText(R.string.close)
-                .build();
-        dialog.show();
+        View view = LayoutInflater.from(requireActivity()).inflate(R.layout.fragment_languages, null);
+        AlertDialog dialog = new MaterialAlertDialogBuilder(requireActivity())
+                .setTitle(R.string.pref_theme_header)
+                .setView(view)
+                .setNegativeButton(R.string.close, null)
+                .create();
 
-        ListView listView = (ListView) dialog.findViewById(R.id.listview);
+        ListView listView = view.findViewById(R.id.listview);
         mChosenTheme = mCurrentTheme = Preferences.get(requireActivity()).getTheme();
 
         listView.setAdapter(new ThemeAdapter(requireActivity(), Arrays.asList(Theme.values()), mCurrentTheme.ordinal()));

--- a/library/src/main/java/candybar/lib/helpers/LauncherHelper.java
+++ b/library/src/main/java/candybar/lib/helpers/LauncherHelper.java
@@ -16,7 +16,8 @@ import androidx.annotation.ChecksSdkIntAtLeast;
 import androidx.annotation.DrawableRes;
 import androidx.annotation.NonNull;
 
-import com.afollestad.materialdialogs.MaterialDialog;
+import androidx.appcompat.app.AlertDialog;
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 
 import java.lang.reflect.Method;
 import java.util.Arrays;
@@ -1150,12 +1151,10 @@ public class LauncherHelper {
                 + ((!isInstalled && (steps.length > 0)) ? "\n\n" : "")
                 + (isInstalled ? "" : installPrompt); // prompt to install the launcher
 
-        new MaterialDialog.Builder(context)
-                .typeface(TypefaceHelper.getMedium(context), TypefaceHelper.getRegular(context))
-                .title(launcher.type.name)
-                .content(content)
-                .positiveText(positiveButton)
-                .onPositive((dialog, which) -> {
+        new MaterialAlertDialogBuilder(context)
+                .setTitle(launcher.type.name)
+                .setMessage(content)
+                .setPositiveButton(positiveButton, (dialog, which) -> {
                     if (isInstalled) {
                         logLauncherManualApply(launcherPackageName, "confirm");
                         if (launcher.type.settingsActivityName == null) return;
@@ -1179,8 +1178,7 @@ public class LauncherHelper {
                         openGooglePlay(context, launcherPackageName);
                     }
                 })
-                .negativeText(negativeButton)
-                .onNegative(((dialog, which) -> {
+                .setNegativeButton(negativeButton, ((dialog, which) -> {
                     logLauncherManualApply(launcherPackageName, "cancel");
                 }))
                 .show();
@@ -1223,16 +1221,14 @@ public class LauncherHelper {
                         Arrays.copyOfRange(instructions, 1, instructions.length - 2)
                 )
                 + "\n\n" + instructions[instructions.length - 1];
-        new MaterialDialog.Builder(context)
-                .typeface(TypefaceHelper.getMedium(context), TypefaceHelper.getRegular(context))
-                .title(launcherName)
-                .content(
+        new MaterialAlertDialogBuilder(context)
+                .setTitle(launcherName)
+                .setMessage(
                         launcher.type.manualApplyFunc.getCompatibilityMessage(context, launcherName)
                                 + "\n\n"
                                 + (launcher.type.manualApplyFunc.isSupported(launcherPackage) ? compatibleText : incompatibleText)
                 )
-                .positiveText(android.R.string.yes)
-                .onPositive((dialog, which) -> {
+                .setPositiveButton(android.R.string.yes, (dialog, which) -> {
                     logLauncherManualApply(launcherPackage, "confirm");
                     if (launcher.type.manualApplyFunc.isSupported(launcherPackage)) {
                         String packageName = "com.samsung.android.themedesigner";
@@ -1267,8 +1263,7 @@ public class LauncherHelper {
                         }
                     }
                 })
-                .negativeText(android.R.string.cancel)
-                .onNegative(((dialog, which) -> {
+                .setNegativeButton(android.R.string.cancel, ((dialog, which) -> {
                     logLauncherManualApply(launcherPackage, "cancel");
                 }))
                 .show();
@@ -1285,12 +1280,10 @@ public class LauncherHelper {
     }
 
     private static void launcherIncompatibleCustomMessage(Context context, String launcherName, String message) {
-        new MaterialDialog.Builder(context)
-                .typeface(TypefaceHelper.getMedium(context), TypefaceHelper.getRegular(context))
-                .title(launcherName)
-                .content(message)
-                .positiveText(android.R.string.yes)
-                .onPositive((dialog, which) -> {
+        new MaterialAlertDialogBuilder(context)
+                .setTitle(launcherName)
+                .setMessage(message)
+                .setPositiveButton(android.R.string.yes, (dialog, which) -> {
                     CandyBarApplication.getConfiguration().getAnalyticsHandler().logEvent(
                             "click",
                             new HashMap<>() {{
@@ -1307,8 +1300,7 @@ public class LauncherHelper {
                                 R.string.no_browser), Toast.LENGTH_LONG).show();
                     }
                 })
-                .negativeText(android.R.string.cancel)
-                .onNegative(((dialog, which) -> {
+                .setNegativeButton(android.R.string.cancel, ((dialog, which) -> {
                     CandyBarApplication.getConfiguration().getAnalyticsHandler().logEvent(
                             "click",
                             new HashMap<>() {{
@@ -1322,11 +1314,10 @@ public class LauncherHelper {
     }
 
     private static void notInstalledError(Context context, String launcherName) {
-        new MaterialDialog.Builder(context)
-                .typeface(TypefaceHelper.getMedium(context), TypefaceHelper.getRegular(context))
-                .title(launcherName)
-                .content(R.string.apply_launcher_not_installable, launcherName)
-                .positiveText(context.getResources().getString(R.string.close))
+        new MaterialAlertDialogBuilder(context)
+                .setTitle(launcherName)
+                .setMessage(context.getResources().getString(R.string.apply_launcher_not_installable, launcherName))
+                .setPositiveButton(context.getResources().getString(R.string.close), null)
                 .show();
     }
 

--- a/library/src/main/java/candybar/lib/helpers/LicenseCallbackHelper.java
+++ b/library/src/main/java/candybar/lib/helpers/LicenseCallbackHelper.java
@@ -8,7 +8,9 @@ import android.os.Looper;
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatActivity;
 
-import com.afollestad.materialdialogs.MaterialDialog;
+import androidx.appcompat.app.AlertDialog;
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
+import android.widget.ProgressBar;
 import com.danimahardhika.android.helpers.license.LicenseCallback;
 import com.danimahardhika.android.helpers.license.LicenseHelper;
 
@@ -37,17 +39,17 @@ public class LicenseCallbackHelper implements LicenseCallback {
 
     private final Context mContext;
     private final Runnable mCallback;
-    private final MaterialDialog mDialog;
+    private final AlertDialog mDialog;
 
     public LicenseCallbackHelper(@NonNull Context context, Runnable callback) {
         mContext = context;
         mCallback = callback;
 
-        mDialog = new MaterialDialog.Builder(mContext)
-                .typeface(TypefaceHelper.getMedium(mContext), TypefaceHelper.getRegular(mContext))
-                .content(R.string.license_checking)
-                .progress(true, 0)
-                .build();
+        ProgressBar progressBar = new ProgressBar(mContext);
+        mDialog = new MaterialAlertDialogBuilder(mContext)
+                .setMessage(R.string.license_checking)
+                .setView(progressBar)
+                .create();
         mDialog.setCancelable(false);
         mDialog.setCanceledOnTouchOutside(false);
     }
@@ -81,29 +83,22 @@ public class LicenseCallbackHelper implements LicenseCallback {
     private void showLicenseDialog(LicenseHelper.Status status) {
         int message = status == LicenseHelper.Status.SUCCESS ?
                 R.string.license_check_success : R.string.license_check_failed;
-        new MaterialDialog.Builder(mContext)
-                .typeface(TypefaceHelper.getMedium(mContext), TypefaceHelper.getRegular(mContext))
-                .title(R.string.license_check)
-                .content(message)
-                .positiveText(R.string.close)
-                .onPositive((dialog, which) -> {
+        new MaterialAlertDialogBuilder(mContext)
+                .setTitle(R.string.license_check)
+                .setMessage(message)
+                .setPositiveButton(R.string.close, (dialog, which) -> {
                     onLicenseChecked(status);
-                    dialog.dismiss();
                 })
-                .cancelable(false)
-                .canceledOnTouchOutside(false)
+                .setCancelable(false)
                 .show();
     }
 
     private void showRetryDialog() {
-        new MaterialDialog.Builder(mContext)
-                .typeface(TypefaceHelper.getMedium(mContext), TypefaceHelper.getRegular(mContext))
-                .title(R.string.license_check)
-                .content(R.string.license_check_retry)
-                .positiveText(R.string.close)
-                .cancelable(false)
-                .canceledOnTouchOutside(false)
-                .onPositive((dialog, which) -> ((AppCompatActivity) mContext).finish())
+        new MaterialAlertDialogBuilder(mContext)
+                .setTitle(R.string.license_check)
+                .setMessage(R.string.license_check_retry)
+                .setPositiveButton(R.string.close, (dialog, which) -> ((AppCompatActivity) mContext).finish())
+                .setCancelable(false)
                 .show();
     }
 

--- a/library/src/main/java/candybar/lib/helpers/ReportBugsHelper.java
+++ b/library/src/main/java/candybar/lib/helpers/ReportBugsHelper.java
@@ -10,8 +10,10 @@ import android.widget.EditText;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
-import com.afollestad.materialdialogs.DialogAction;
-import com.afollestad.materialdialogs.MaterialDialog;
+import androidx.appcompat.app.AlertDialog;
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
+import android.view.LayoutInflater;
+import android.view.View;
 import com.danimahardhika.android.helpers.core.utils.LogUtil;
 import com.google.android.material.textfield.TextInputLayout;
 
@@ -61,25 +63,27 @@ public class ReportBugsHelper {
     private static final String UTF8 = "UTF8";
 
     public static void prepareReportBugs(@NonNull Context context) {
-        MaterialDialog dialog = new MaterialDialog.Builder(context)
-                .customView(R.layout.dialog_report_bugs, true)
-                .typeface(TypefaceHelper.getMedium(context), TypefaceHelper.getRegular(context))
-                .positiveText(R.string.report_bugs_send)
-                .negativeText(R.string.close)
-                .build();
+        View view = LayoutInflater.from(context).inflate(R.layout.dialog_report_bugs, null);
+        AlertDialog dialog = new MaterialAlertDialogBuilder(context)
+                .setView(view)
+                .setPositiveButton(R.string.report_bugs_send, null)
+                .setNegativeButton(R.string.close, null)
+                .create();
 
-        EditText editText = (EditText) dialog.findViewById(R.id.input_desc);
-        TextInputLayout inputLayout = (TextInputLayout) dialog.findViewById(R.id.input_layout);
+        EditText editText = view.findViewById(R.id.input_desc);
+        TextInputLayout inputLayout = view.findViewById(R.id.input_layout);
 
-        dialog.getActionButton(DialogAction.POSITIVE).setOnClickListener(view -> {
-            if (editText.getText().length() != 0) {
-                inputLayout.setErrorEnabled(false);
-                new ReportBugsTask(context, editText.getText().toString()).executeOnThreadPool();
-                dialog.dismiss();
-                return;
-            }
+        dialog.setOnShowListener(d -> {
+            dialog.getButton(AlertDialog.BUTTON_POSITIVE).setOnClickListener(v -> {
+                if (editText.getText().length() != 0) {
+                    inputLayout.setErrorEnabled(false);
+                    new ReportBugsTask(context, editText.getText().toString()).executeOnThreadPool();
+                    dialog.dismiss();
+                    return;
+                }
 
-            inputLayout.setError(context.getResources().getString(R.string.report_bugs_desc_empty));
+                inputLayout.setError(context.getResources().getString(R.string.report_bugs_desc_empty));
+            });
         });
         dialog.show();
     }

--- a/library/src/main/java/candybar/lib/helpers/RequestHelper.java
+++ b/library/src/main/java/candybar/lib/helpers/RequestHelper.java
@@ -15,7 +15,7 @@ import android.util.Log;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
-import com.afollestad.materialdialogs.MaterialDialog;
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 import com.danimahardhika.android.helpers.core.TimeHelper;
 import com.danimahardhika.android.helpers.core.utils.LogUtil;
 
@@ -417,20 +417,18 @@ public class RequestHelper {
 
         if (reset)
             message += "\n\n" + context.getResources().getString(R.string.request_limit_reset);
-        new MaterialDialog.Builder(context)
-                .typeface(TypefaceHelper.getMedium(context), TypefaceHelper.getRegular(context))
-                .title(R.string.request_title)
-                .content(message)
-                .positiveText(R.string.close)
+        new MaterialAlertDialogBuilder(context)
+                .setTitle(R.string.request_title)
+                .setMessage(message)
+                .setPositiveButton(R.string.close, null)
                 .show();
     }
 
     public static void showPremiumRequestRequired(@NonNull Context context) {
-        new MaterialDialog.Builder(context)
-                .typeface(TypefaceHelper.getMedium(context), TypefaceHelper.getRegular(context))
-                .title(R.string.request_title)
-                .content(R.string.premium_request_required)
-                .positiveText(R.string.close)
+        new MaterialAlertDialogBuilder(context)
+                .setTitle(R.string.request_title)
+                .setMessage(R.string.premium_request_required)
+                .setPositiveButton(R.string.close, null)
                 .show();
     }
 
@@ -438,11 +436,10 @@ public class RequestHelper {
         String message = context.getResources().getString(R.string.premium_request_limit,
                 Preferences.get(context).getPremiumRequestCount());
         message += " " + context.getResources().getString(R.string.premium_request_limit1, selected);
-        new MaterialDialog.Builder(context)
-                .typeface(TypefaceHelper.getMedium(context), TypefaceHelper.getRegular(context))
-                .title(R.string.premium_request)
-                .content(message)
-                .positiveText(R.string.close)
+        new MaterialAlertDialogBuilder(context)
+                .setTitle(R.string.premium_request)
+                .setMessage(message)
+                .setPositiveButton(R.string.close, null)
                 .show();
     }
 
@@ -450,42 +447,38 @@ public class RequestHelper {
         String message = context.getResources().getString(
                 R.string.premium_request_already_purchased,
                 Preferences.get(context).getPremiumRequestCount());
-        new MaterialDialog.Builder(context)
-                .typeface(TypefaceHelper.getMedium(context), TypefaceHelper.getRegular(context))
-                .title(R.string.premium_request)
-                .content(message)
-                .positiveText(R.string.close)
+        new MaterialAlertDialogBuilder(context)
+                .setTitle(R.string.premium_request)
+                .setMessage(message)
+                .setPositiveButton(R.string.close, null)
                 .show();
     }
 
     public static boolean isReadyToSendPremiumRequest(@NonNull Context context) {
         boolean isReady = Preferences.get(context).isConnectedToNetwork();
         if (!isReady) {
-            new MaterialDialog.Builder(context)
-                    .typeface(TypefaceHelper.getMedium(context), TypefaceHelper.getRegular(context))
-                    .title(R.string.premium_request)
-                    .content(R.string.premium_request_no_internet)
-                    .positiveText(R.string.close)
+            new MaterialAlertDialogBuilder(context)
+                    .setTitle(R.string.premium_request)
+                    .setMessage(R.string.premium_request_no_internet)
+                    .setPositiveButton(R.string.close, null)
                     .show();
         }
         return isReady;
     }
 
     public static void showPremiumRequestConsumeFailed(@NonNull Context context) {
-        new MaterialDialog.Builder(context)
-                .typeface(TypefaceHelper.getMedium(context), TypefaceHelper.getRegular(context))
-                .title(R.string.premium_request)
-                .content(R.string.premium_request_consume_failed)
-                .positiveText(R.string.close)
+        new MaterialAlertDialogBuilder(context)
+                .setTitle(R.string.premium_request)
+                .setMessage(R.string.premium_request_consume_failed)
+                .setPositiveButton(R.string.close, null)
                 .show();
     }
 
     public static void showPremiumRequestExist(@NonNull Context context) {
-        new MaterialDialog.Builder(context)
-                .typeface(TypefaceHelper.getMedium(context), TypefaceHelper.getRegular(context))
-                .title(R.string.premium_request)
-                .content(R.string.premium_request_exist)
-                .positiveText(R.string.close)
+        new MaterialAlertDialogBuilder(context)
+                .setTitle(R.string.premium_request)
+                .setMessage(R.string.premium_request_exist)
+                .setPositiveButton(R.string.close, null)
                 .show();
     }
 

--- a/library/src/main/java/candybar/lib/tasks/ReportBugsTask.java
+++ b/library/src/main/java/candybar/lib/tasks/ReportBugsTask.java
@@ -10,7 +10,9 @@ import android.widget.Toast;
 
 import androidx.appcompat.app.AppCompatActivity;
 
-import com.afollestad.materialdialogs.MaterialDialog;
+import androidx.appcompat.app.AlertDialog;
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
+import android.widget.ProgressBar;
 import com.danimahardhika.android.helpers.core.FileHelper;
 import com.danimahardhika.android.helpers.core.utils.LogUtil;
 
@@ -23,7 +25,6 @@ import candybar.lib.R;
 import candybar.lib.helpers.DeviceHelper;
 import candybar.lib.helpers.ReportBugsHelper;
 import candybar.lib.helpers.RequestHelper;
-import candybar.lib.helpers.TypefaceHelper;
 import candybar.lib.preferences.Preferences;
 import candybar.lib.utils.AsyncTaskBase;
 
@@ -51,7 +52,7 @@ public class ReportBugsTask extends AsyncTaskBase {
     private final String mDescription;
     private String mZipPath = null;
     private StringBuilder mStringBuilder;
-    private MaterialDialog mDialog;
+    private AlertDialog mDialog;
 
     public ReportBugsTask(Context context, String description) {
         mContext = new WeakReference<>(context);
@@ -60,14 +61,12 @@ public class ReportBugsTask extends AsyncTaskBase {
 
     @Override
     protected void preRun() {
-        mDialog = new MaterialDialog.Builder(mContext.get())
-                .typeface(TypefaceHelper.getMedium(mContext.get()), TypefaceHelper.getRegular(mContext.get()))
-                .content(R.string.report_bugs_building)
-                .progress(true, 0)
-                .progressIndeterminateStyle(true)
-                .cancelable(false)
-                .canceledOnTouchOutside(false)
-                .build();
+        ProgressBar progressBar = new ProgressBar(mContext.get());
+        mDialog = new MaterialAlertDialogBuilder(mContext.get())
+                .setMessage(R.string.report_bugs_building)
+                .setView(progressBar)
+                .setCancelable(false)
+                .create();
         mDialog.show();
         mStringBuilder = new StringBuilder();
     }

--- a/library/src/main/java/candybar/lib/tasks/WallpaperApplyTask.java
+++ b/library/src/main/java/candybar/lib/tasks/WallpaperApplyTask.java
@@ -15,7 +15,9 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
 
-import com.afollestad.materialdialogs.MaterialDialog;
+import androidx.appcompat.app.AlertDialog;
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
+import android.widget.ProgressBar;
 import com.bumptech.glide.Glide;
 import com.bumptech.glide.load.engine.DiskCacheStrategy;
 import com.danimahardhika.android.helpers.core.ColorHelper;
@@ -59,7 +61,7 @@ public class WallpaperApplyTask extends AsyncTaskBase implements WallpaperProper
     private Apply mApply;
     private RectF mRectF;
     private Wallpaper mWallpaper;
-    private MaterialDialog mDialog;
+    private AlertDialog mDialog;
 
     public WallpaperApplyTask(@NonNull Context context, @NonNull Wallpaper wallpaper) {
         mContext = new WeakReference<>(context);
@@ -85,18 +87,14 @@ public class WallpaperApplyTask extends AsyncTaskBase implements WallpaperProper
                 color = ColorHelper.getAttributeColor(mContext.get(), com.google.android.material.R.attr.colorSecondary);
             }
 
-            final MaterialDialog.Builder builder = new MaterialDialog.Builder(mContext.get());
-            builder.widgetColor(color)
-                    .typeface(TypefaceHelper.getMedium(mContext.get()), TypefaceHelper.getRegular(mContext.get()))
-                    .progress(true, 0)
-                    .cancelable(false)
-                    .progressIndeterminateStyle(true)
-                    .content(R.string.wallpaper_loading)
-                    .positiveColor(color)
-                    .positiveText(android.R.string.cancel)
-                    .onPositive((dialog, which) -> cancel(true));
+            ProgressBar progressBar = new ProgressBar(mContext.get());
+            final AlertDialog.Builder builder = new MaterialAlertDialogBuilder(mContext.get());
+            builder.setMessage(R.string.wallpaper_loading)
+                    .setView(progressBar)
+                    .setCancelable(false)
+                    .setPositiveButton(android.R.string.cancel, (dialog, which) -> cancel(true));
 
-            mDialog = builder.build();
+            mDialog = builder.create();
         }
 
         if (!mDialog.isShowing()) mDialog.show();
@@ -233,7 +231,7 @@ public class WallpaperApplyTask extends AsyncTaskBase implements WallpaperProper
                              */
                             LogUtil.d(String.format(Locale.getDefault(), "loaded bitmap: %d x %d",
                                     loadedBitmap.getWidth(), loadedBitmap.getHeight()));
-                            runOnUiThread(() -> mDialog.setContent(R.string.wallpaper_applying));
+                            runOnUiThread(() -> mDialog.setMessage(mContext.get().getResources().getString(R.string.wallpaper_applying)));
 
                             Bitmap bitmap = loadedBitmap;
                             if (Preferences.get(mContext.get()).isCropWallpaper() && adjustedRectF != null) {

--- a/library/src/main/res/layout/fragment_intent_chooser_item_list.xml
+++ b/library/src/main/res/layout/fragment_intent_chooser_item_list.xml
@@ -10,13 +10,12 @@
     android:background="?attr/selectableItemBackground"
     android:theme="@style/RippleStyle">
 
-    <me.zhanghai.android.materialprogressbar.MaterialProgressBar
+    <ProgressBar
         android:id="@+id/progress"
         android:layout_width="@dimen/icon_size_medium"
         android:layout_height="@dimen/icon_size_medium"
         android:indeterminate="true"
-        android:visibility="gone"
-        style="@style/Widget.MaterialProgressBar.ProgressBar" />
+        android:visibility="gone" />
 
     <ImageView
         android:id="@+id/icon"

--- a/library/src/main/res/values-v31/dimens.xml
+++ b/library/src/main/res/values-v31/dimens.xml
@@ -1,6 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools">
     <dimen name="card_corner_radius">18dp</dimen>
-    <dimen name="md_bg_corner_radius" tools:override="true">18dp</dimen>
-    <dimen name="md_action_corner_radius" tools:override="true">100dp</dimen>
 </resources>

--- a/library/src/main/res/values/dimens.xml
+++ b/library/src/main/res/values/dimens.xml
@@ -46,8 +46,6 @@
     <dimen name="tab_text">14sp</dimen>
 
     <!-- Dialog -->
-    <dimen name="md_bg_corner_radius" tools:override="true">10dp</dimen>
-    <dimen name="md_action_corner_radius" tools:override="true">6dp</dimen>
 
     <!-- Splash Screen -->
     <dimen name="splash_screen_logo">120dp</dimen>

--- a/library/src/main/res/values/themes.xml
+++ b/library/src/main/res/values/themes.xml
@@ -98,14 +98,6 @@
         <item name="actionModeStyle">@style/ActionModeStyle</item>
         <item name="actionBarTheme">@style/ActionBarOverlay</item>
 
-        <item name="md_background_color">?cb_cardBackground</item>
-        <item name="md_positive_color">?cb_colorAccent</item>
-        <item name="md_neutral_color">?cb_primaryText</item>
-        <item name="md_negative_color">?cb_primaryText</item>
-        <item name="md_content_color">?cb_primaryText</item>
-        <item name="md_link_color">?cb_colorAccent</item>
-        <item name="md_widget_color">?cb_colorAccent</item>
-        <item name="md_item_color">?cb_primaryText</item>
     </style>
 
     <style name="CandyBar.Theme.App.DayNight" parent="CandyBar.Theme.Base" />

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'org.gradle.toolchains.foojay-resolver-convention' version '0.8.0'
+    id 'org.gradle.toolchains.foojay-resolver-convention' version '1.0.0'
 }
 
 include ':app', ':library', ':extLibs:PreLollipopTransitions'


### PR DESCRIPTION
Remove the material-dialogs dependency and replace it with Google's built in solution.

Doing this as part of an attempt to future-proof the project by removing old dependencies. This PR is based on my Gradle update branch here #251 

I've tested it locally, and all the dialogs seem to be doing what they're supposed to be, but with MaterialAlertDialogBuilder and alertDialog instead. 

For transparency: the changes were made by Gemini inside Android Studio.
