### PR TITLE
Replace Cafebar with snackbar

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,14 +8,14 @@ android {
             storeFile file('candybar.jks')
             storePassword 'candybar'
 
-            v1SigningEnabled true
-            v2SigningEnabled true
+            v1SigningEnabled = true
+            v2SigningEnabled = true
         }
     }
 
     compileSdk = rootProject.ext.CompileSdk
 
-    namespace 'com.candybar.dev'
+    namespace = 'com.candybar.dev'
 
     defaultConfig {
         applicationId 'com.candybar.dev'
@@ -38,8 +38,8 @@ android {
 
     buildTypes {
         release {
-            signingConfig signingConfigs.release
-            minifyEnabled true
+            signingConfig = signingConfigs.release
+            minifyEnabled = true
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
@@ -49,7 +49,7 @@ android {
     }
 
     lint {
-        abortOnError false
+        abortOnError = false
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -26,8 +26,8 @@ allprojects {
         VersionName = "$major.$minor.$patch"
 
         MinSdk = 21
-        TargetSdk = 36
-        CompileSdk = 36
+        TargetSdk = 37
+        CompileSdk = 37
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:9.2.1'
+        classpath 'com.android.tools.build:gradle:9.3.1'
     }
 }
 
@@ -13,8 +13,8 @@ allprojects {
     repositories {
         mavenCentral()
         google()
-        maven { url 'https://jitpack.io' }
-        maven { url 'https://maven.google.com' }
+        maven { url = 'https://jitpack.io' }
+        maven { url = 'https://maven.google.com' }
     }
 
     rootProject.ext {

--- a/extLibs/PreLollipopTransitions/build.gradle
+++ b/extLibs/PreLollipopTransitions/build.gradle
@@ -71,5 +71,5 @@ java {
 }
 
 dependencies {
-    implementation 'androidx.appcompat:appcompat:1.8.0'
+    implementation 'androidx.appcompat:appcompat:1.7.0' // higher versions don't support targetSDK 21 anymore
 }

--- a/extLibs/PreLollipopTransitions/build.gradle
+++ b/extLibs/PreLollipopTransitions/build.gradle
@@ -71,5 +71,5 @@ java {
 }
 
 dependencies {
-    implementation 'androidx.appcompat:appcompat:1.7.0' // higher versions don't support targetSDK 21 anymore
+    implementation 'androidx.appcompat:appcompat:1.7.0' // higher versions don't support MinSdk 21 anymore
 }

--- a/extLibs/PreLollipopTransitions/build.gradle
+++ b/extLibs/PreLollipopTransitions/build.gradle
@@ -37,7 +37,7 @@ publishing {
 android {
     compileSdk = rootProject.ext.CompileSdk
 
-    namespace 'com.kogitune.activity_transition'
+    namespace = 'com.kogitune.activity_transition'
 
     defaultConfig {
         minSdkVersion rootProject.ext.MinSdk
@@ -45,7 +45,7 @@ android {
 
     buildTypes {
         release {
-            minifyEnabled false
+            minifyEnabled = false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
@@ -71,5 +71,5 @@ java {
 }
 
 dependencies {
-    implementation 'androidx.appcompat:appcompat:1.7.0'
+    implementation 'androidx.appcompat:appcompat:1.8.0'
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,6 @@
 # http://www.gradle.org/docs/current/userguide/build_environment.html
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-android.enableJetifier=true
 android.useAndroidX=true
 org.gradle.jvmargs=-Xms512m -Xmx2048m
 # kapt.incremental.apt=false

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,6 +6,7 @@
 # http://www.gradle.org/docs/current/userguide/build_environment.html
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
+android.enableJetifier=true
 android.useAndroidX=true
 org.gradle.jvmargs=-Xms512m -Xmx2048m
 # kapt.incremental.apt=false

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.7.0-bin.zip

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -105,7 +105,7 @@ dependencies {
     api 'dev.jahir.KustomAPI:api:6369c37'
     api 'dev.jahir.KustomAPI:preset:6369c37'
 
-    implementation 'androidx.work:work-runtime:2.11.2'
+    implementation 'androidx.work:work-runtime:2.10.5'  // 2.10.5 or higher doesn't support targetSDK 21 anymore
     implementation 'androidx.recyclerview:recyclerview:1.4.0'
     implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.2.0'
     implementation 'androidx.palette:palette:1.0.0'

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -99,17 +99,17 @@ dependencies {
     implementation project(':extLibs:PreLollipopTransitions')
 
     api 'androidx.annotation:annotation:1.10.0'
-    api 'androidx.appcompat:appcompat:1.7.0' // 1.7.0 or higher doesn't support targetSDK 21 anymore
+    api 'androidx.appcompat:appcompat:1.7.0' // higher versions don't support targetSDK 21 anymore
     api 'com.google.android.apps.muzei:muzei-api:3.4.2'
     api 'com.android.billingclient:billing:9.1.0'
     api 'dev.jahir.KustomAPI:api:6369c37'
     api 'dev.jahir.KustomAPI:preset:6369c37'
 
-    implementation 'androidx.work:work-runtime:2.10.5'  // 2.10.5 or higher doesn't support targetSDK 21 anymore
+    implementation 'androidx.work:work-runtime:2.10.5' // higher versions don't support targetSDK 21 anymore
     implementation 'androidx.recyclerview:recyclerview:1.4.0'
     implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.2.0'
     implementation 'androidx.palette:palette:1.0.0'
-    implementation 'com.google.android.material:material:1.13.0' // 1.14.0 or higher doesn't support targetSDK 21 anymore
+    implementation 'com.google.android.material:material:1.13.0' // higher versions don't support targetSDK 21 anymore
     implementation 'androidx.viewpager2:viewpager2:1.1.0'
     implementation 'com.google.android.play:review:2.0.2'
     implementation 'androidx.core:core-splashscreen:1.2.0'
@@ -117,7 +117,7 @@ dependencies {
     implementation 'com.bluelinelabs:logansquare:1.3.7'
     annotationProcessor 'com.bluelinelabs:logansquare-compiler:1.3.7'
 
-    implementation 'com.github.bumptech.glide:glide:5.0.5' // 5.0.5 or higher doesn't support targetSDK 21 anymore
+    implementation 'com.github.bumptech.glide:glide:5.0.5' // higher versions don't support targetSDK 21 anymore
     annotationProcessor 'com.github.bumptech.glide:compiler:5.0.9'
 
     implementation 'com.squareup.okhttp3:okhttp:5.4.0'

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -117,7 +117,7 @@ dependencies {
     implementation 'com.bluelinelabs:logansquare:1.3.7'
     annotationProcessor 'com.bluelinelabs:logansquare-compiler:1.3.7'
 
-    implementation 'com.github.bumptech.glide:glide:5.0.9'
+    implementation 'com.github.bumptech.glide:glide:5.0.5' // 5.0.5 or higher doesn't support targetSDK 21 anymore
     annotationProcessor 'com.github.bumptech.glide:compiler:5.0.9'
 
     implementation 'com.squareup.okhttp3:okhttp:5.4.0'

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -99,17 +99,17 @@ dependencies {
     implementation project(':extLibs:PreLollipopTransitions')
 
     api 'androidx.annotation:annotation:1.10.0'
-    api 'androidx.appcompat:appcompat:1.7.0' // higher versions don't support targetSDK 21 anymore
+    api 'androidx.appcompat:appcompat:1.7.0' // higher versions don't support MinSdk 21 anymore
     api 'com.google.android.apps.muzei:muzei-api:3.4.2'
-    api 'com.android.billingclient:billing:8.0.0' // higher versions don't support targetSDK 21 anymore
+    api 'com.android.billingclient:billing:8.0.0' // higher versions don't support MinSdk 21 anymore
     api 'dev.jahir.KustomAPI:api:6369c37'
     api 'dev.jahir.KustomAPI:preset:6369c37'
 
-    implementation 'androidx.work:work-runtime:2.10.5' // higher versions don't support targetSDK 21 anymore
+    implementation 'androidx.work:work-runtime:2.10.5' // higher versions don't support MinSdk 21 anymore
     implementation 'androidx.recyclerview:recyclerview:1.4.0'
     implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.2.0'
     implementation 'androidx.palette:palette:1.0.0'
-    implementation 'com.google.android.material:material:1.13.0' // higher versions don't support targetSDK 21 anymore
+    implementation 'com.google.android.material:material:1.13.0' // higher versions don't support MinSdk 21 anymore
     implementation 'androidx.viewpager2:viewpager2:1.1.0'
     implementation 'com.google.android.play:review:2.0.2'
     implementation 'androidx.core:core-splashscreen:1.2.0'
@@ -117,7 +117,7 @@ dependencies {
     implementation 'com.bluelinelabs:logansquare:1.3.7'
     annotationProcessor 'com.bluelinelabs:logansquare-compiler:1.3.7'
 
-    implementation 'com.github.bumptech.glide:glide:5.0.5' // higher versions don't support targetSDK 21 anymore
+    implementation 'com.github.bumptech.glide:glide:5.0.5' // higher versions don't support MinSdk 21 anymore
     annotationProcessor 'com.github.bumptech.glide:compiler:5.0.9'
 
     implementation 'com.squareup.okhttp3:okhttp:5.4.0'

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -109,7 +109,7 @@ dependencies {
     implementation 'androidx.recyclerview:recyclerview:1.4.0'
     implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.2.0'
     implementation 'androidx.palette:palette:1.0.0'
-    implementation 'com.google.android.material:material:1.14.0'
+    implementation 'com.google.android.material:material:1.13.0' // 1.14.0 or higher doesn't support targetSDK 21 anymore
     implementation 'androidx.viewpager2:viewpager2:1.1.0'
     implementation 'com.google.android.play:review:2.0.2'
     implementation 'androidx.core:core-splashscreen:1.2.0'

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -131,7 +131,6 @@ dependencies {
     implementation 'com.github.zixpo:recycler-fast-scroll:6add4dff39'
     implementation 'me.zhanghai.android.fastscroll:library:1.3.0'
 
-    implementation 'com.github.danimahardhika:cafebar:1.3.2'
     implementation 'com.github.danimahardhika.android-helpers:core:-SNAPSHOT'
     implementation 'com.github.danimahardhika.android-helpers:animation:0.1.0'
     implementation 'com.github.danimahardhika.android-helpers:license:0.1.0'

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -101,7 +101,7 @@ dependencies {
     api 'androidx.annotation:annotation:1.10.0'
     api 'androidx.appcompat:appcompat:1.7.0' // higher versions don't support targetSDK 21 anymore
     api 'com.google.android.apps.muzei:muzei-api:3.4.2'
-    api 'com.android.billingclient:billing:9.1.0'
+    api 'com.android.billingclient:billing:8.0.0' // higher versions don't support targetSDK 21 anymore
     api 'dev.jahir.KustomAPI:api:6369c37'
     api 'dev.jahir.KustomAPI:preset:6369c37'
 

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -99,7 +99,7 @@ dependencies {
     implementation project(':extLibs:PreLollipopTransitions')
 
     api 'androidx.annotation:annotation:1.10.0'
-    api 'androidx.appcompat:appcompat:1.8.0'
+    api 'androidx.appcompat:appcompat:1.7.0' // 1.7.0 or higher doesn't support targetSDK 21 anymore
     api 'com.google.android.apps.muzei:muzei-api:3.4.2'
     api 'com.android.billingclient:billing:9.1.0'
     api 'dev.jahir.KustomAPI:api:6369c37'

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -121,7 +121,7 @@ dependencies {
     annotationProcessor 'com.github.bumptech.glide:compiler:5.0.9'
 
     implementation 'com.squareup.okhttp3:okhttp:5.4.0'
-    implementation 'com.afollestad.material-dialogs:core:3.3.0'
+    implementation 'com.afollestad.material-dialogs:core:0.9.6.0'
     implementation 'com.afollestad.material-dialogs:commons:0.9.6.0'
     implementation 'com.mikhaellopez:circularimageview:4.3.1'
     implementation 'com.github.Baseflow:PhotoView:2.3.0'

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -46,11 +46,11 @@ allprojects {
 android {
     compileSdk = rootProject.ext.CompileSdk
 
-    namespace 'candybar.lib'
+    namespace = 'candybar.lib'
 
     defaultConfig {
         minSdkVersion rootProject.ext.MinSdk
-        vectorDrawables.useSupportLibrary true
+        vectorDrawables.useSupportLibrary = true
         buildConfigField 'String', 'VERSION_NAME', "\"${rootProject.ext.VersionName}\""
     }
 
@@ -76,7 +76,7 @@ android {
     }
 
     lint {
-        abortOnError false
+        abortOnError = false
         disable 'MissingTranslation'
         targetSdk 36
     }
@@ -98,30 +98,30 @@ java {
 dependencies {
     implementation project(':extLibs:PreLollipopTransitions')
 
-    api 'androidx.annotation:annotation:1.9.1'
-    api 'androidx.appcompat:appcompat:1.7.1'
+    api 'androidx.annotation:annotation:1.10.0'
+    api 'androidx.appcompat:appcompat:1.8.0'
     api 'com.google.android.apps.muzei:muzei-api:3.4.2'
-    api 'com.android.billingclient:billing:8.0.0'
+    api 'com.android.billingclient:billing:9.1.0'
     api 'dev.jahir.KustomAPI:api:6369c37'
     api 'dev.jahir.KustomAPI:preset:6369c37'
 
-    implementation 'androidx.work:work-runtime:2.10.5'
+    implementation 'androidx.work:work-runtime:2.11.2'
     implementation 'androidx.recyclerview:recyclerview:1.4.0'
-    implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.1.0'
+    implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.2.0'
     implementation 'androidx.palette:palette:1.0.0'
-    implementation 'com.google.android.material:material:1.13.0'
+    implementation 'com.google.android.material:material:1.14.0'
     implementation 'androidx.viewpager2:viewpager2:1.1.0'
     implementation 'com.google.android.play:review:2.0.2'
-    implementation 'androidx.core:core-splashscreen:1.0.1'
+    implementation 'androidx.core:core-splashscreen:1.2.0'
 
     implementation 'com.bluelinelabs:logansquare:1.3.7'
     annotationProcessor 'com.bluelinelabs:logansquare-compiler:1.3.7'
 
-    implementation 'com.github.bumptech.glide:glide:5.0.5'
-    annotationProcessor 'com.github.bumptech.glide:compiler:5.0.5'
+    implementation 'com.github.bumptech.glide:glide:5.0.9'
+    annotationProcessor 'com.github.bumptech.glide:compiler:5.0.9'
 
-    implementation 'com.squareup.okhttp3:okhttp:5.2.1'
-    implementation 'com.afollestad.material-dialogs:core:0.9.6.0'
+    implementation 'com.squareup.okhttp3:okhttp:5.4.0'
+    implementation 'com.afollestad.material-dialogs:core:3.3.0'
     implementation 'com.afollestad.material-dialogs:commons:0.9.6.0'
     implementation 'com.mikhaellopez:circularimageview:4.3.1'
     implementation 'com.github.Baseflow:PhotoView:2.3.0'

--- a/library/src/main/java/candybar/lib/fragments/PresetsFragment.java
+++ b/library/src/main/java/candybar/lib/fragments/PresetsFragment.java
@@ -28,8 +28,7 @@ import androidx.recyclerview.widget.RecyclerView;
 import com.bumptech.glide.Glide;
 import com.danimahardhika.android.helpers.core.ColorHelper;
 import com.danimahardhika.android.helpers.core.utils.LogUtil;
-import com.danimahardhika.cafebar.CafeBar;
-import com.danimahardhika.cafebar.CafeBarTheme;
+import com.google.android.material.snackbar.Snackbar;
 import com.pluscubed.recyclerfastscroll.RecyclerFastScroller;
 
 import java.io.IOException;
@@ -41,7 +40,6 @@ import java.util.concurrent.CountDownLatch;
 import candybar.lib.R;
 import candybar.lib.adapters.PresetsAdapter;
 import candybar.lib.applications.CandyBarApplication;
-import candybar.lib.helpers.TypefaceHelper;
 import candybar.lib.items.Preset;
 import candybar.lib.preferences.Preferences;
 import candybar.lib.utils.AsyncTaskBase;
@@ -119,13 +117,7 @@ public class PresetsFragment extends Fragment {
                 Manifest.permission.READ_EXTERNAL_STORAGE) != PackageManager.PERMISSION_GRANTED) {
             registerForActivityResult(new ActivityResultContracts.RequestPermission(), isGranted -> {
                 if (!isGranted) {
-                    CafeBar.builder(requireActivity())
-                            .theme(CafeBarTheme.Custom(ColorHelper.getAttributeColor(requireActivity(), R.attr.cb_cardBackground)))
-                            .floating(true)
-                            .fitSystemWindow()
-                            .duration(CafeBar.Duration.MEDIUM)
-                            .typeface(TypefaceHelper.getRegular(requireActivity()), TypefaceHelper.getBold(requireActivity()))
-                            .content(R.string.presets_storage_permission)
+                    Snackbar.make(requireView(), R.string.presets_storage_permission, Snackbar.LENGTH_LONG)
                             .show();
                 }
 

--- a/library/src/main/java/candybar/lib/tasks/WallpaperApplyTask.java
+++ b/library/src/main/java/candybar/lib/tasks/WallpaperApplyTask.java
@@ -9,6 +9,7 @@ import android.graphics.Paint;
 import android.graphics.RectF;
 import android.os.Build;
 import android.util.Log;
+import android.view.View;
 import android.widget.Toast;
 
 import androidx.annotation.NonNull;
@@ -20,8 +21,7 @@ import com.bumptech.glide.Glide;
 import com.bumptech.glide.load.engine.DiskCacheStrategy;
 import com.danimahardhika.android.helpers.core.ColorHelper;
 import com.danimahardhika.android.helpers.core.utils.LogUtil;
-import com.danimahardhika.cafebar.CafeBar;
-import com.danimahardhika.cafebar.CafeBarTheme;
+import com.google.android.material.snackbar.Snackbar;
 
 import java.lang.ref.WeakReference;
 import java.util.Locale;
@@ -352,13 +352,9 @@ public class WallpaperApplyTask extends AsyncTaskBase implements WallpaperProper
         }
 
         if (ok) {
-            CafeBar.builder(mContext.get())
-                    .theme(CafeBarTheme.Custom(ColorHelper.getAttributeColor(
-                            mContext.get(), R.attr.cb_cardBackground)))
-                    .contentTypeface(TypefaceHelper.getRegular(mContext.get()))
-                    .floating(true)
-                    .fitSystemWindow()
-                    .content(R.string.wallpaper_applied)
+            Activity activity = (Activity) mContext.get();
+            View view = activity.findViewById(android.R.id.content);
+            Snackbar.make(view, R.string.wallpaper_applied, Snackbar.LENGTH_LONG)
                     .show();
         } else {
             Toast.makeText(mContext.get(), R.string.wallpaper_apply_failed,

--- a/library/src/main/java/candybar/lib/utils/WallpaperDownloader.java
+++ b/library/src/main/java/candybar/lib/utils/WallpaperDownloader.java
@@ -1,22 +1,22 @@
 package candybar.lib.utils;
 
 import android.app.DownloadManager;
+import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Environment;
 import android.util.Log;
+import android.view.View;
 import android.webkit.URLUtil;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.StringRes;
 
-import com.danimahardhika.android.helpers.core.ColorHelper;
 import com.danimahardhika.android.helpers.core.utils.LogUtil;
 import com.danimahardhika.android.helpers.permission.PermissionHelper;
-import com.danimahardhika.cafebar.CafeBar;
-import com.danimahardhika.cafebar.CafeBarTheme;
+import com.google.android.material.snackbar.Snackbar;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -24,7 +24,6 @@ import java.io.InputStream;
 import java.io.OutputStream;
 
 import candybar.lib.R;
-import candybar.lib.helpers.TypefaceHelper;
 import candybar.lib.helpers.WallpaperHelper;
 import candybar.lib.items.Wallpaper;
 
@@ -60,41 +59,27 @@ public class WallpaperDownloader {
         return this;
     }
 
-    private void showCafeBar(int res) {
-        CafeBar.builder(mContext)
-                .theme(CafeBarTheme.Custom(ColorHelper.getAttributeColor(mContext, R.attr.cb_cardBackground)))
-                .contentTypeface(TypefaceHelper.getRegular(mContext))
-                .content(res)
-                .floating(true)
-                .fitSystemWindow()
-                .show();
+    private void showSnackbar(int res) {
+        if (!(mContext instanceof Activity)) return;
+        View view = ((Activity) mContext).findViewById(android.R.id.content);
+        Snackbar.make(view, res, Snackbar.LENGTH_LONG).show();
     }
 
-    private void showOpenFileCafeBar(@StringRes int textRes, File target) {
-        CafeBar.builder(mContext)
-                .theme(CafeBarTheme.Custom(ColorHelper.getAttributeColor(mContext, R.attr.cb_cardBackground)))
-                .floating(true)
-                .fitSystemWindow()
-                .duration(CafeBar.Duration.MEDIUM)
-                .typeface(TypefaceHelper.getRegular(mContext), TypefaceHelper.getBold(mContext))
-                .content(textRes)
-                .neutralText(R.string.open)
-                .onNeutral(cafeBar -> {
+    private void showOpenFileSnackbar(@StringRes int textRes, File target) {
+        if (!(mContext instanceof Activity)) return;
+        View view = ((Activity) mContext).findViewById(android.R.id.content);
+        Snackbar.make(view, textRes, Snackbar.LENGTH_LONG)
+                .setAction(R.string.open, v -> {
                     Uri uri = Build.VERSION.SDK_INT >= Build.VERSION_CODES.N
                             ? Uri.parse(target.toString())
                             : Uri.fromFile(target);
 
-                    if (uri == null) {
-                        cafeBar.dismiss();
-                        return;
-                    }
+                    if (uri == null) return;
 
                     mContext.startActivity(new Intent()
                             .setAction(Intent.ACTION_VIEW)
                             .setDataAndType(uri, "image/*")
                             .setFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION));
-
-                    cafeBar.dismiss();
                 })
                 .show();
     }
@@ -114,7 +99,7 @@ public class WallpaperDownloader {
 
             if (!directory.exists() && !directory.mkdirs()) {
                 LogUtil.e("Unable to create directory " + directory);
-                showCafeBar(R.string.wallpaper_download_failed);
+                showSnackbar(R.string.wallpaper_download_failed);
                 return;
             }
         }
@@ -123,7 +108,7 @@ public class WallpaperDownloader {
             File target = new File(directory, fileName);
 
             if (target.exists()) {
-                showOpenFileCafeBar(R.string.wallpaper_already_downloaded, target);
+                showOpenFileSnackbar(R.string.wallpaper_already_downloaded, target);
                 return;
             }
         } catch (SecurityException e) {
@@ -138,7 +123,7 @@ public class WallpaperDownloader {
         }
 
         if (url.startsWith("assets://")) {
-            showCafeBar(R.string.wallpaper_downloading);
+            showSnackbar(R.string.wallpaper_downloading);
 
             try {
                 File output;
@@ -160,10 +145,10 @@ public class WallpaperDownloader {
 
                 mContext.sendBroadcast(new Intent(Intent.ACTION_MEDIA_SCANNER_SCAN_FILE, Uri.fromFile(output)));
 
-                showOpenFileCafeBar(R.string.wallpaper_download_success, output);
+                showOpenFileSnackbar(R.string.wallpaper_download_success, output);
             } catch (Exception e) {
                 LogUtil.e(Log.getStackTraceString(e));
-                showCafeBar(R.string.wallpaper_download_failed);
+                showSnackbar(R.string.wallpaper_download_failed);
             }
         } else {
             DownloadManager.Request request = new DownloadManager.Request(Uri.parse(url));
@@ -182,11 +167,11 @@ public class WallpaperDownloader {
                 }
             } catch (IllegalArgumentException e) {
                 LogUtil.e(Log.getStackTraceString(e));
-                showCafeBar(R.string.wallpaper_download_failed);
+                showSnackbar(R.string.wallpaper_download_failed);
                 return;
             }
 
-            showCafeBar(R.string.wallpaper_downloading);
+            showSnackbar(R.string.wallpaper_downloading);
         }
     }
 

--- a/library/src/main/res/xml/dashboard_licenses.xml
+++ b/library/src/main/res/xml/dashboard_licenses.xml
@@ -17,22 +17,6 @@
         limitations under the License.
     </license>
 
-    <license name="CafeBar">
-        Copyright (c) 2017 Dani Mahardhika
-
-        Licensed under the Apache License, Version 2.0 (the "License");
-        you may not use this file except in compliance with the License.
-        You may obtain a copy of the License at
-
-        http://www.apache.org/licenses/LICENSE-2.0
-
-        Unless required by applicable law or agreed to in writing, software
-        distributed under the License is distributed on an "AS IS" BASIS,
-        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-        See the License for the specific language governing permissions and
-        limitations under the License.
-    </license>
-
     <license name="Android Helpers">
         Copyright (c) 2017 Dani Mahardhika
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'org.gradle.toolchains.foojay-resolver-convention' version '0.8.0'
+    id 'org.gradle.toolchains.foojay-resolver-convention' version '1.0.0'
 }
 
 include ':app', ':library', ':extLibs:PreLollipopTransitions'


### PR DESCRIPTION
Remove the Cafebar dependency and replace it with Google's built in solution.

Doing this as part of an attempt to future-proof the project by removing old dependencies. This PR is based on my Gradle update branch here: https://github.com/zixpo/candybar/pull/251

I've tested it locally, and had no issues

For transparency, the changes were made by Gemini inside Android Studio.