### PR TITLE
Cleanup WalpaperLoaderTask

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,14 +8,14 @@ android {
             storeFile file('candybar.jks')
             storePassword 'candybar'
 
-            v1SigningEnabled true
-            v2SigningEnabled true
+            v1SigningEnabled = true
+            v2SigningEnabled = true
         }
     }
 
     compileSdk = rootProject.ext.CompileSdk
 
-    namespace 'com.candybar.dev'
+    namespace = 'com.candybar.dev'
 
     defaultConfig {
         applicationId 'com.candybar.dev'
@@ -38,8 +38,8 @@ android {
 
     buildTypes {
         release {
-            signingConfig signingConfigs.release
-            minifyEnabled true
+            signingConfig = signingConfigs.release
+            minifyEnabled = true
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
@@ -49,7 +49,7 @@ android {
     }
 
     lint {
-        abortOnError false
+        abortOnError = false
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -26,8 +26,8 @@ allprojects {
         VersionName = "$major.$minor.$patch"
 
         MinSdk = 21
-        TargetSdk = 36
-        CompileSdk = 36
+        TargetSdk = 37
+        CompileSdk = 37
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:9.2.1'
+        classpath 'com.android.tools.build:gradle:9.3.1'
     }
 }
 
@@ -13,8 +13,8 @@ allprojects {
     repositories {
         mavenCentral()
         google()
-        maven { url 'https://jitpack.io' }
-        maven { url 'https://maven.google.com' }
+        maven { url = 'https://jitpack.io' }
+        maven { url = 'https://maven.google.com' }
     }
 
     rootProject.ext {

--- a/extLibs/PreLollipopTransitions/build.gradle
+++ b/extLibs/PreLollipopTransitions/build.gradle
@@ -71,5 +71,5 @@ java {
 }
 
 dependencies {
-    implementation 'androidx.appcompat:appcompat:1.8.0'
+    implementation 'androidx.appcompat:appcompat:1.7.0' // higher versions don't support targetSDK 21 anymore
 }

--- a/extLibs/PreLollipopTransitions/build.gradle
+++ b/extLibs/PreLollipopTransitions/build.gradle
@@ -71,5 +71,5 @@ java {
 }
 
 dependencies {
-    implementation 'androidx.appcompat:appcompat:1.7.0' // higher versions don't support targetSDK 21 anymore
+    implementation 'androidx.appcompat:appcompat:1.7.0' // higher versions don't support MinSdk 21 anymore
 }

--- a/extLibs/PreLollipopTransitions/build.gradle
+++ b/extLibs/PreLollipopTransitions/build.gradle
@@ -37,7 +37,7 @@ publishing {
 android {
     compileSdk = rootProject.ext.CompileSdk
 
-    namespace 'com.kogitune.activity_transition'
+    namespace = 'com.kogitune.activity_transition'
 
     defaultConfig {
         minSdkVersion rootProject.ext.MinSdk
@@ -45,7 +45,7 @@ android {
 
     buildTypes {
         release {
-            minifyEnabled false
+            minifyEnabled = false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
@@ -71,5 +71,5 @@ java {
 }
 
 dependencies {
-    implementation 'androidx.appcompat:appcompat:1.7.0'
+    implementation 'androidx.appcompat:appcompat:1.8.0'
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,6 @@
 # http://www.gradle.org/docs/current/userguide/build_environment.html
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-android.enableJetifier=true
 android.useAndroidX=true
 org.gradle.jvmargs=-Xms512m -Xmx2048m
 # kapt.incremental.apt=false

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,6 +6,7 @@
 # http://www.gradle.org/docs/current/userguide/build_environment.html
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
+android.enableJetifier=true
 android.useAndroidX=true
 org.gradle.jvmargs=-Xms512m -Xmx2048m
 # kapt.incremental.apt=false

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.7.0-bin.zip

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -105,7 +105,7 @@ dependencies {
     api 'dev.jahir.KustomAPI:api:6369c37'
     api 'dev.jahir.KustomAPI:preset:6369c37'
 
-    implementation 'androidx.work:work-runtime:2.11.2'
+    implementation 'androidx.work:work-runtime:2.10.5'  // 2.10.5 or higher doesn't support targetSDK 21 anymore
     implementation 'androidx.recyclerview:recyclerview:1.4.0'
     implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.2.0'
     implementation 'androidx.palette:palette:1.0.0'

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -99,17 +99,17 @@ dependencies {
     implementation project(':extLibs:PreLollipopTransitions')
 
     api 'androidx.annotation:annotation:1.10.0'
-    api 'androidx.appcompat:appcompat:1.7.0' // 1.7.0 or higher doesn't support targetSDK 21 anymore
+    api 'androidx.appcompat:appcompat:1.7.0' // higher versions don't support targetSDK 21 anymore
     api 'com.google.android.apps.muzei:muzei-api:3.4.2'
     api 'com.android.billingclient:billing:9.1.0'
     api 'dev.jahir.KustomAPI:api:6369c37'
     api 'dev.jahir.KustomAPI:preset:6369c37'
 
-    implementation 'androidx.work:work-runtime:2.10.5'  // 2.10.5 or higher doesn't support targetSDK 21 anymore
+    implementation 'androidx.work:work-runtime:2.10.5' // higher versions don't support targetSDK 21 anymore
     implementation 'androidx.recyclerview:recyclerview:1.4.0'
     implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.2.0'
     implementation 'androidx.palette:palette:1.0.0'
-    implementation 'com.google.android.material:material:1.13.0' // 1.14.0 or higher doesn't support targetSDK 21 anymore
+    implementation 'com.google.android.material:material:1.13.0' // higher versions don't support targetSDK 21 anymore
     implementation 'androidx.viewpager2:viewpager2:1.1.0'
     implementation 'com.google.android.play:review:2.0.2'
     implementation 'androidx.core:core-splashscreen:1.2.0'
@@ -117,7 +117,7 @@ dependencies {
     implementation 'com.bluelinelabs:logansquare:1.3.7'
     annotationProcessor 'com.bluelinelabs:logansquare-compiler:1.3.7'
 
-    implementation 'com.github.bumptech.glide:glide:5.0.5' // 5.0.5 or higher doesn't support targetSDK 21 anymore
+    implementation 'com.github.bumptech.glide:glide:5.0.5' // higher versions don't support targetSDK 21 anymore
     annotationProcessor 'com.github.bumptech.glide:compiler:5.0.9'
 
     implementation 'com.squareup.okhttp3:okhttp:5.4.0'

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -117,7 +117,7 @@ dependencies {
     implementation 'com.bluelinelabs:logansquare:1.3.7'
     annotationProcessor 'com.bluelinelabs:logansquare-compiler:1.3.7'
 
-    implementation 'com.github.bumptech.glide:glide:5.0.9'
+    implementation 'com.github.bumptech.glide:glide:5.0.5' // 5.0.5 or higher doesn't support targetSDK 21 anymore
     annotationProcessor 'com.github.bumptech.glide:compiler:5.0.9'
 
     implementation 'com.squareup.okhttp3:okhttp:5.4.0'

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -99,17 +99,17 @@ dependencies {
     implementation project(':extLibs:PreLollipopTransitions')
 
     api 'androidx.annotation:annotation:1.10.0'
-    api 'androidx.appcompat:appcompat:1.7.0' // higher versions don't support targetSDK 21 anymore
+    api 'androidx.appcompat:appcompat:1.7.0' // higher versions don't support MinSdk 21 anymore
     api 'com.google.android.apps.muzei:muzei-api:3.4.2'
-    api 'com.android.billingclient:billing:8.0.0' // higher versions don't support targetSDK 21 anymore
+    api 'com.android.billingclient:billing:8.0.0' // higher versions don't support MinSdk 21 anymore
     api 'dev.jahir.KustomAPI:api:6369c37'
     api 'dev.jahir.KustomAPI:preset:6369c37'
 
-    implementation 'androidx.work:work-runtime:2.10.5' // higher versions don't support targetSDK 21 anymore
+    implementation 'androidx.work:work-runtime:2.10.5' // higher versions don't support MinSdk 21 anymore
     implementation 'androidx.recyclerview:recyclerview:1.4.0'
     implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.2.0'
     implementation 'androidx.palette:palette:1.0.0'
-    implementation 'com.google.android.material:material:1.13.0' // higher versions don't support targetSDK 21 anymore
+    implementation 'com.google.android.material:material:1.13.0' // higher versions don't support MinSdk 21 anymore
     implementation 'androidx.viewpager2:viewpager2:1.1.0'
     implementation 'com.google.android.play:review:2.0.2'
     implementation 'androidx.core:core-splashscreen:1.2.0'
@@ -117,7 +117,7 @@ dependencies {
     implementation 'com.bluelinelabs:logansquare:1.3.7'
     annotationProcessor 'com.bluelinelabs:logansquare-compiler:1.3.7'
 
-    implementation 'com.github.bumptech.glide:glide:5.0.5' // higher versions don't support targetSDK 21 anymore
+    implementation 'com.github.bumptech.glide:glide:5.0.5' // higher versions don't support MinSdk 21 anymore
     annotationProcessor 'com.github.bumptech.glide:compiler:5.0.9'
 
     implementation 'com.squareup.okhttp3:okhttp:5.4.0'

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -109,7 +109,7 @@ dependencies {
     implementation 'androidx.recyclerview:recyclerview:1.4.0'
     implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.2.0'
     implementation 'androidx.palette:palette:1.0.0'
-    implementation 'com.google.android.material:material:1.14.0'
+    implementation 'com.google.android.material:material:1.13.0' // 1.14.0 or higher doesn't support targetSDK 21 anymore
     implementation 'androidx.viewpager2:viewpager2:1.1.0'
     implementation 'com.google.android.play:review:2.0.2'
     implementation 'androidx.core:core-splashscreen:1.2.0'

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -101,7 +101,7 @@ dependencies {
     api 'androidx.annotation:annotation:1.10.0'
     api 'androidx.appcompat:appcompat:1.7.0' // higher versions don't support targetSDK 21 anymore
     api 'com.google.android.apps.muzei:muzei-api:3.4.2'
-    api 'com.android.billingclient:billing:9.1.0'
+    api 'com.android.billingclient:billing:8.0.0' // higher versions don't support targetSDK 21 anymore
     api 'dev.jahir.KustomAPI:api:6369c37'
     api 'dev.jahir.KustomAPI:preset:6369c37'
 

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -99,7 +99,7 @@ dependencies {
     implementation project(':extLibs:PreLollipopTransitions')
 
     api 'androidx.annotation:annotation:1.10.0'
-    api 'androidx.appcompat:appcompat:1.8.0'
+    api 'androidx.appcompat:appcompat:1.7.0' // 1.7.0 or higher doesn't support targetSDK 21 anymore
     api 'com.google.android.apps.muzei:muzei-api:3.4.2'
     api 'com.android.billingclient:billing:9.1.0'
     api 'dev.jahir.KustomAPI:api:6369c37'

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -121,7 +121,7 @@ dependencies {
     annotationProcessor 'com.github.bumptech.glide:compiler:5.0.9'
 
     implementation 'com.squareup.okhttp3:okhttp:5.4.0'
-    implementation 'com.afollestad.material-dialogs:core:3.3.0'
+    implementation 'com.afollestad.material-dialogs:core:0.9.6.0'
     implementation 'com.afollestad.material-dialogs:commons:0.9.6.0'
     implementation 'com.mikhaellopez:circularimageview:4.3.1'
     implementation 'com.github.Baseflow:PhotoView:2.3.0'

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -46,11 +46,11 @@ allprojects {
 android {
     compileSdk = rootProject.ext.CompileSdk
 
-    namespace 'candybar.lib'
+    namespace = 'candybar.lib'
 
     defaultConfig {
         minSdkVersion rootProject.ext.MinSdk
-        vectorDrawables.useSupportLibrary true
+        vectorDrawables.useSupportLibrary = true
         buildConfigField 'String', 'VERSION_NAME', "\"${rootProject.ext.VersionName}\""
     }
 
@@ -76,7 +76,7 @@ android {
     }
 
     lint {
-        abortOnError false
+        abortOnError = false
         disable 'MissingTranslation'
         targetSdk 36
     }
@@ -98,30 +98,30 @@ java {
 dependencies {
     implementation project(':extLibs:PreLollipopTransitions')
 
-    api 'androidx.annotation:annotation:1.9.1'
-    api 'androidx.appcompat:appcompat:1.7.1'
+    api 'androidx.annotation:annotation:1.10.0'
+    api 'androidx.appcompat:appcompat:1.8.0'
     api 'com.google.android.apps.muzei:muzei-api:3.4.2'
-    api 'com.android.billingclient:billing:8.0.0'
+    api 'com.android.billingclient:billing:9.1.0'
     api 'dev.jahir.KustomAPI:api:6369c37'
     api 'dev.jahir.KustomAPI:preset:6369c37'
 
-    implementation 'androidx.work:work-runtime:2.10.5'
+    implementation 'androidx.work:work-runtime:2.11.2'
     implementation 'androidx.recyclerview:recyclerview:1.4.0'
-    implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.1.0'
+    implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.2.0'
     implementation 'androidx.palette:palette:1.0.0'
-    implementation 'com.google.android.material:material:1.13.0'
+    implementation 'com.google.android.material:material:1.14.0'
     implementation 'androidx.viewpager2:viewpager2:1.1.0'
     implementation 'com.google.android.play:review:2.0.2'
-    implementation 'androidx.core:core-splashscreen:1.0.1'
+    implementation 'androidx.core:core-splashscreen:1.2.0'
 
     implementation 'com.bluelinelabs:logansquare:1.3.7'
     annotationProcessor 'com.bluelinelabs:logansquare-compiler:1.3.7'
 
-    implementation 'com.github.bumptech.glide:glide:5.0.5'
-    annotationProcessor 'com.github.bumptech.glide:compiler:5.0.5'
+    implementation 'com.github.bumptech.glide:glide:5.0.9'
+    annotationProcessor 'com.github.bumptech.glide:compiler:5.0.9'
 
-    implementation 'com.squareup.okhttp3:okhttp:5.2.1'
-    implementation 'com.afollestad.material-dialogs:core:0.9.6.0'
+    implementation 'com.squareup.okhttp3:okhttp:5.4.0'
+    implementation 'com.afollestad.material-dialogs:core:3.3.0'
     implementation 'com.afollestad.material-dialogs:commons:0.9.6.0'
     implementation 'com.mikhaellopez:circularimageview:4.3.1'
     implementation 'com.github.Baseflow:PhotoView:2.3.0'

--- a/library/src/main/java/candybar/lib/tasks/WallpaperPropertiesLoaderTask.java
+++ b/library/src/main/java/candybar/lib/tasks/WallpaperPropertiesLoaderTask.java
@@ -1,7 +1,6 @@
 package candybar.lib.tasks;
 
 import android.content.Context;
-import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.util.Log;
 
@@ -12,11 +11,9 @@ import com.bumptech.glide.Glide;
 import com.danimahardhika.android.helpers.core.utils.LogUtil;
 
 import java.io.File;
-import java.io.InputStream;
 import java.lang.ref.WeakReference;
 
 import candybar.lib.databases.Database;
-import candybar.lib.helpers.WallpaperHelper;
 import candybar.lib.items.ImageSize;
 import candybar.lib.items.Wallpaper;
 import candybar.lib.utils.AsyncTaskBase;
@@ -58,30 +55,37 @@ public class WallpaperPropertiesLoaderTask extends AsyncTaskBase {
                 Thread.sleep(1);
                 if (mWallpaper == null) return false;
 
+                Context context = mContext.get();
+                if (context == null) return false;
+
                 if (mWallpaper.getDimensions() != null &&
                         mWallpaper.getMimeType() != null &&
                         mWallpaper.getSize() > 0) {
                     return false;
                 }
 
-                final BitmapFactory.Options options = new BitmapFactory.Options();
+                String url = mWallpaper.getURL();
+                if (url.startsWith("assets://")) {
+                    url = url.replaceFirst("assets://", "file:///android_asset/");
+                }
 
-                InputStream stream = WallpaperHelper.getStream(mContext.get(), mWallpaper.getURL());
+                File file = Glide.with(context)
+                        .asFile()
+                        .load(url)
+                        .submit()
+                        .get();
 
-                if (stream != null) {
-                    Bitmap bitmap = BitmapFactory.decodeStream(stream, null, options);
+                if (file != null && file.exists()) {
+                    final BitmapFactory.Options options = new BitmapFactory.Options();
+                    options.inJustDecodeBounds = true;
+                    BitmapFactory.decodeFile(file.getAbsolutePath(), options);
 
                     ImageSize imageSize = new ImageSize(options.outWidth, options.outHeight);
                     mWallpaper.setDimensions(imageSize);
                     mWallpaper.setMimeType(options.outMimeType);
-
-                    int contentLength = bitmap.getAllocationByteCount();
-                    if (contentLength > 0) {
-                        mWallpaper.setSize(contentLength);
-                    }
+                    mWallpaper.setSize((int) file.length());
 
                     Database.get(mContext.get()).updateWallpaper(mWallpaper);
-                    stream.close();
                     return true;
                 }
                 return false;
@@ -95,23 +99,6 @@ public class WallpaperPropertiesLoaderTask extends AsyncTaskBase {
 
     @Override
     protected void postRun(boolean ok) {
-        if (ok && mContext.get() != null && !((AppCompatActivity) mContext.get()).isFinishing()) {
-            if (mWallpaper.getSize() <= 0) {
-                try {
-                    File target = Glide.with(mContext.get())
-                            .asFile()
-                            .load(mWallpaper.getURL())
-                            .onlyRetrieveFromCache(true)
-                            .submit()
-                            .get();
-                    if (target != null && target.exists()) {
-                        mWallpaper.setSize((int) target.length());
-                    }
-                } catch (Exception ignored) {
-                }
-            }
-        }
-
         if (mCallback.get() != null) {
             mCallback.get().onPropertiesReceived(mWallpaper);
         }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'org.gradle.toolchains.foojay-resolver-convention' version '0.8.0'
+    id 'org.gradle.toolchains.foojay-resolver-convention' version '1.0.0'
 }
 
 include ':app', ':library', ':extLibs:PreLollipopTransitions'


### PR DESCRIPTION
Got this message from the Play Console:

Improve your app's performance with bitmap image optimization

Your app manually downloads and decodes images from the network in the following places: Decoded in `candybar.lib.tasks.WallpaperPropertiesLoaderTask.run` Downloaded in `candybar.lib.helpers.WallpaperHelper.getStream `This can lead to excessive memory usage, poor performance, and app crashes. To reduce memory usage, we recommend using an image loading library to automatically handle downsampling, caching, and memory management for you.

Merge #251 first :) 

-----

Changes Made:
1. Replaced Manual Network Download:
- Removed the use of `HttpURLConnection` via `WallpaperHelper.getStream()` for fetching images.
- Implemented `Glide.with(context).asFile().load(url).submit().get()` to download the wallpaper. This leverages Glide's built-in networking (OkHttp) and automatic caching, preventing redundant downloads and reducing data usage.
2. Optimized Image Decoding:
- Replaced the full image decoding (`BitmapFactory.decodeStream`) which loaded the entire bitmap into memory just to read dimensions.
- Implemented `BitmapFactory.Options` with `inJustDecodeBounds = true` to extract dimensions and MIME type from the downloaded file without allocating memory for the full bitmap.
3. Improved Metadata Accuracy:
- Changed how the wallpaper size is determined. It now uses the actual file length (file.length()) instead of the memory footprint of the decoded bitmap, providing a more accurate "file size" value for the dashboard.
4. Handled Assets Protocol:
- Added support to convert `assets:// URIs` to Glide-compatible android_asset URIs, ensuring local wallpapers are also handled through the optimized pipeline.
5. Cleaned Up Code:
- Removed unused imports (InputStream, WallpaperHelper, Bitmap) and added safety null checks for Context. 

Generated with Google's built in Android studio AI 